### PR TITLE
superMap should use the idProp

### DIFF
--- a/src/can-connect.js
+++ b/src/can-connect.js
@@ -7,8 +7,8 @@ var idMerge = require("./helpers/id-merge");
  * @param {Object} options
  */
 var connect = function(behaviors, options){
-	
-	
+
+
 	behaviors = behaviors.map(function(behavior, index){
 		var sortedIndex;
 		if(typeof behavior === "string") {
@@ -84,7 +84,7 @@ var core = connect.behavior("base",function(base){
 		id: function(instance){
 			return instance[this.idProp || "id"];
 		},
-		idProp: "id",
+		idProp: base.idProp || "id",
 		listSet: function(list){
 			return list[this.listSetProp];
 		},

--- a/test/super-map_test.js
+++ b/test/super-map_test.js
@@ -1,0 +1,31 @@
+var QUnit = require("steal-qunit");
+var fixture = require("can/util/fixture/fixture");
+var Map = require("can/map/map");
+var superMap = require("can-connect/super-map");
+
+QUnit.test("uses idProp", function(){
+
+	var Restaurant = Map.extend({});
+
+	var connection = superMap({
+		resource: "/api/restaurants",
+		idProp: '_id',
+		Map: Restaurant,
+		List: Restaurant.List,
+		name: "restaurant"
+	});
+
+	fixture({
+		"GET /api/restaurants/{_id}": function(request){
+			return {id: 5};
+		}
+	});
+
+	stop();
+	connection.getInstanceData({_id: 5}).then(function(data){
+		deepEqual(data, {id: 5}, "findOne");
+		start();
+	});
+
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -18,3 +18,4 @@ require("./real-time_test");
 require("./model_test");
 
 require("./tag_test");
+require("./super-map_test");


### PR DESCRIPTION
Connections should always use idProp if it exists and then fallback to
"id" as the default. Fixes #3