### PR TITLE
Test and fix for idProp not being submitted as query paramaters.

### DIFF
--- a/src/data/localstorage-cache/localstorage-cache.js
+++ b/src/data/localstorage-cache/localstorage-cache.js
@@ -283,7 +283,6 @@ module.exports = connect.behavior("data-localstorage-cache",function(baseConnect
 				}
 			});
 			var id = this.id(props);
-			debugger;
 			localStorage.removeItem(this.name+"/instance/"+id);
 			return Promise.resolve({});
 		}

--- a/src/data/url/data-url_test.js
+++ b/src/data/url/data-url_test.js
@@ -65,3 +65,24 @@ QUnit.test("basics", function(assert){
 	});
 	
 });
+
+QUnit.test('idProp is not part of the parameters', function() {
+	var connection = persist({
+		idProp: 'id',
+		url: "api/todos/"
+	});
+
+	fixture({
+		"GET api/todos/2": function (req) {
+			ok(!req.data.id);
+			deepEqual(req.data, {other: 'prop'});
+			return [{id: 1}];
+		}
+	});
+
+	stop();
+	connection.getData({id: 2, other: 'prop'}).then(function() {
+		start();
+	});
+
+});

--- a/src/data/url/url.js
+++ b/src/data/url/url.js
@@ -159,7 +159,6 @@ var makeAjax = function ( ajaxOb, data, type, ajax ) {
 
 	// Substitute in data for any templated parts of the URL.
 	params.url = helpers.sub(params.url, params.data, true);
-
 	return ajax(helpers.extend({
 		type: type || 'post',
 		dataType: 'json'

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -27,15 +27,19 @@ module.exports = helpers = {
 		}
 		return obj;
 	},
-	getObject: function(prop, data){
-		return data[prop];
+	getObject: function(prop, data, remove) {
+		var res = data[prop];
+		if(remove) {
+			delete data[prop];
+		}
+		return res;
 	},
 	sub: function (str, data, remove) {
 		var obs = [];
 		str = str || '';
 		obs.push(str.replace(strReplacer, function (whole, inside) {
 			// Convert inside to type.
-			var ob = helpers.getObject(inside, data, remove === true ? false : undefined);
+			var ob = helpers.getObject(inside, data, remove);
 			if (ob === undefined || ob === null) {
 				obs = null;
 				return '';


### PR DESCRIPTION
This PR makes sure that URL properties do not also get submitted as query parameters by getting the `remove` parameter for `helpers.getObject` actually do what it is supposed to.