### PR TITLE
"can/map" to "can-map" in CanJS integration example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -359,7 +359,7 @@ Todo.List = can.List.extend({Map: Todo},{});
 
 var todoConnection = connect([
     "data-url",
-    "can/map",
+    "can-map",
     "constructor",
     "constructor-store"
   ],{


### PR DESCRIPTION
Was receiving an undefined behaviour error when doing something similar to this example until I made this change