### PR TITLE
Add readyState to XHR getter/setter

### DIFF
--- a/src/fixture/fixture.js
+++ b/src/fixture/fixture.js
@@ -177,8 +177,8 @@ XMLHttpRequest.prototype.getAllResponseHeaders = function(){
 	return this._xhr.getAllResponseHeaders.apply(this._xhr, arguments);
 };
 
-["response","responseText", "responseType", "responseURL","status","statusText"].forEach(function(prop){
-	
+["response","responseText", "responseType", "responseURL","status","statusText", "readyState"].forEach(function(prop){
+
 	Object.defineProperty(XMLHttpRequest.prototype, prop, {
 		get: function(){
 			return this._xhr[prop];
@@ -187,13 +187,13 @@ XMLHttpRequest.prototype.getAllResponseHeaders = function(){
 			this._xhr[prop] = newVal;
 		}
 	});
-	
+
 });
 
 
 
 XMLHttpRequest.prototype.send = function(data) {
-	
+
 	var settings = {
 		url: this.url,
 		data: data,
@@ -210,23 +210,23 @@ XMLHttpRequest.prototype.send = function(data) {
 		} catch(e) {
 			settings.data = deparam( settings.data );
 		}
-		
+
 	}
-	
+
 	var self = this;
 	updateSettings(settings, settings);
 
 	// If the call is a fixture call, we run the same type of code as we would
 	// with jQuery's ajaxTransport.
 	if (settings.fixture) {
-		var timeout, 
+		var timeout,
 			stopped = false;
 
 		// set a timeout that simulates making a request ....
 		timeout = setTimeout(function () {
 			// if the user wants to call success on their own, we allow it ...
 			var success = function () {
-				
+
 				var response = extractResponse.apply(settings, arguments),
 					status = response[0];
 
@@ -264,7 +264,7 @@ XMLHttpRequest.prototype.send = function(data) {
 	} else {
 		//debugger;
 		var xhr = new XHR();
-		
+
 		// copy everything on this to the xhr object that is not on `this`'s prototype
 		for(var prop in this){
 			if(!( prop in XMLHttpRequest.prototype) ) {
@@ -440,7 +440,7 @@ helpers.extend(can.fixture, {
 	// Make a store of objects to use when making requests against fixtures.
 	store: function (count, make, filter) {
 		/*jshint eqeqeq:false */
-		
+
 		// the currentId to use when a new instance is created.
 		var	currentId = 0,
 			findOne = function (id) {
@@ -454,7 +454,7 @@ helpers.extend(can.fixture, {
 			types,
 			items,
 			reset;
-			
+
 		if(Array.isArray(count) && typeof count[0] === "string" ){
 			types = count;
 			count = make;
@@ -466,8 +466,8 @@ helpers.extend(can.fixture, {
 			make= filter;
 			filter = arguments[3];
 		}
-		
-		
+
+
 		if(typeof count === "number") {
 			items = [];
 			reset = function () {
@@ -498,12 +498,12 @@ helpers.extend(can.fixture, {
 				items = initialItems.slice(0);
 			};
 		}
-		
+
 
 		// make all items
 		helpers.extend(methods, {
 			findAll: function (request) {
-				
+
 				request = request || {};
 				//copy array of items
 				var retArr = items.slice(0);
@@ -595,8 +595,8 @@ helpers.extend(can.fixture, {
 						responseData[prop] = request.data[prop];
 					}
 				});
-				
-				
+
+
 				return responseData;
 			},
 
@@ -621,7 +621,7 @@ helpers.extend(can.fixture, {
 			 */
 			findOne: function (request, response) {
 				var item = findOne(getId(request));
-				
+
 				if(typeof item === "undefined") {
 					return response(404, 'Requested resource not found');
 				}
@@ -668,7 +668,7 @@ helpers.extend(can.fixture, {
 			destroy: function (request, response) {
 				var id = getId(request),
 					item = findOne(id);
-					
+
 				if(typeof item === "undefined") {
 					return response(404, 'Requested resource not found');
 				}


### PR DESCRIPTION
This adds `readyState` as a property added to fixture's getter/setters.
This is needed because Steal checks readyState to know when an xhr
request is complete.