### PR TITLE
Add readyState to XHR getter/setter

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   },
   "devDependencies": {
     "documentjs": "^0.3.0-pre.5",
-    "steal": "^0.10.1",
+    "steal": "^0.11.0-pre.6",
     "steal-qunit": "0.0.2",
     "testee": "^0.2.0",
     "steal-tools": "^0.10.0"
   },
   "docDependencies": {
-    "steal": "^0.10.1",
+    "steal": "^0.11.0-pre.6",
     "can": "^2.3.0-pre.1",
     "can-set": "^0.2.0",
     "when": "^3.7.3",

--- a/src/fixture/fixture.js
+++ b/src/fixture/fixture.js
@@ -177,7 +177,7 @@ XMLHttpRequest.prototype.getAllResponseHeaders = function(){
 	return this._xhr.getAllResponseHeaders.apply(this._xhr, arguments);
 };
 
-["response","responseText", "responseType", "responseURL","status","statusText"].forEach(function(prop){
+["response","responseText", "responseType", "responseURL","status","statusText","readyState"].forEach(function(prop){
 	
 	Object.defineProperty(XMLHttpRequest.prototype, prop, {
 		get: function(){


### PR DESCRIPTION
This adds readyState as a property added to fixture's getter/setters.
This is needed because Steal checks readyState to know when an xhr
request is complete.