### PR TITLE
Update super-map.js

### DIFF
--- a/src/can/super-map/super-map.js
+++ b/src/can/super-map/super-map.js
@@ -34,11 +34,19 @@ connect.superMap = function(options){
 		"constructor-callbacks-once"];
 
 	if(typeof localStorage !== "undefined") {
-		options.cacheConnection = connect(["data-localstorage-cache"],{
-			name: options.name+"Cache",
-			idProp: options.idProp,
-			algebra: options.algebra
-		});
+		// if no cacheConnection provided, create one
+		if(typeof options.cacheConnection !== 'undefined' && options.cacheConnection.__behaviorName !== 'data-localstorage-cache' && options.cacheConnection.__behaviorName !== 'data-memory-cache') {
+            options.cacheConnection = connect(['data-localstorage-cache'], {
+                name: options.name + 'Cache',
+                idProp: options.idProp,
+                algebra: options.algebra
+            });
+        }
+        // use the cacheConnection options if none are set by superMap
+        options.name = options.name || options.cacheConnection.name;
+        options.idProp = options.idProp || options.cacheConnection.idProp;
+        options.algebra = options.algebra || options.cacheConnection.algebra;
+        
 		behaviors.push("fall-through-cache");
 	}
 	options.ajax = $.ajax;


### PR DESCRIPTION
take the cacheConnection options if none are set in superMap
like:

    var cache = connect(['data-localstorage-cache'],{
        name: "todos"
    });

    var todoConnection = connect.superMap({
        cacheConnection: cache,
        idProp: "_id",
        Map: Todo,
        List: Todo.List,
        url: {
            getListData: 'POST /ajax/auftraggeber/get.ajax'
        }
    });