### PR TITLE
Use canWait global to wait on Promise

### DIFF
--- a/src/constructor/constructor_test.js
+++ b/src/constructor/constructor_test.js
@@ -9,7 +9,24 @@ var logErrorAndStart = function(e){
 	ok(false,"Error "+e);
 	start();
 };
-var wait = require("can-wait");
+
+var makeIframe = function(src){
+	var href = window.location.href.split("/");
+	href.pop();
+	if(href.pop() !== "constructor") {
+		src = "src/constructor/" + src;
+	}
+
+	var iframe = document.createElement('iframe');
+	window.removeMyself = function(){
+		delete window.removeMyself;
+		document.body.removeChild(iframe);
+		QUnit.start();
+	};
+	document.body.appendChild(iframe);
+	iframe.src = src;
+};
+
 // connects the "raw" data to a a constructor function
 // creates ways to CRUD the instances
 QUnit.module("can-connect/constructor",{
@@ -100,38 +117,6 @@ QUnit.test("basics", function(){
 
 });
 
-QUnit.test("Adds data to canWait.data", function(){
-	var Todo = function(values){
-		canSet.helpers.extend(this, values);
-	};
-	var TodoList = function(todos){
-		var listed = todos.slice(0);
-		listed.isList = true;
-		return listed;
-	};
-	var connection = constructor( persist( connect.base({
-		instance: function(values){
-			return new Todo(values);
-		},
-		list: function(arr){
-			return new TodoList(arr.data);
-		},
-		url: "/constructor/todos",
-		name: "todos"
-	}) ));
-
-	fixture({
-		"GET /constructor/todos/2": function(req) {
-			return [{id:2}];
-		}
-	});
-
-	stop();
-
-	wait(function(){
-		connection.get({ id: 2 });
-	}).then(function(responses){
-		equal(responses.length, 1, "There was one piece of data added");
-		ok(responses[0].pageData.todos, "pageData added");
-	}).then(start);
+asyncTest("Adds data to canWait.data", function(){
+	makeIframe("tests/wait.html");
 });

--- a/src/constructor/tests/wait.html
+++ b/src/constructor/tests/wait.html
@@ -1,0 +1,66 @@
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+</script>
+
+<script src="../../../node_modules/steal/steal.js" main="@empty">
+	var wait = require("can-wait");
+
+	function hasQUnit() {
+		return typeof QUnit !== "undefined";
+	}
+
+	wait(function(){
+		Promise.all([
+			System["import"]("can-connect/constructor/"),
+			System["import"]("can-connect/data/url/"),
+			System["import"]("can-connect/can-connect"),
+			System["import"]("can-set"),
+			System["import"]("can-fixture")
+		]).then(function(mods){
+			var constructor = mods[0];
+			var persist = mods[1];
+			var connect = mods[2];
+			var canSet = mods[3];
+			var fixture = mods[4];
+
+			var Todo = function(values){
+				canSet.helpers.extend(this, values);
+			};
+			var TodoList = function(todos){
+				var listed = todos.slice(0);
+				listed.isList = true;
+				return listed;
+			};
+			var connection = constructor( persist( connect.base({
+				instance: function(values){
+					return new Todo(values);
+				},
+				list: function(arr){
+					return new TodoList(arr.data);
+				},
+				url: "/constructor/todos",
+				name: "todos"
+			}) ));
+
+			fixture({
+				"GET /constructor/todos/2": function(req) {
+					return [{id:2}];
+				}
+			});
+
+			connection.get({ id: 2 });
+		});
+	}).then(function(responses){
+		if(hasQUnit()) {
+			QUnit.equal(responses.length, 1, "There was one piece of data added");
+			QUnit.ok(responses[0].pageData.todos, "data added to the response");
+
+			removeMyself();
+		} else {
+			console.log("responses", responses);
+		}
+	}, function(errors){
+		console.error("oh noes", errors);
+	});
+</script>

--- a/src/helpers/wait.js
+++ b/src/helpers/wait.js
@@ -24,14 +24,14 @@ function sortedSetJson(set){
 // server side rendering.
 function addToCanWaitData(promise, name, set){
 	if(typeof canWait !== "undefined" && canWait.data) {
-		return promise.then(function(resp){
+		return promise.then(canWait(function(resp){
 			var data = {};
 			var keyData = data[name] = {};
 			keyData[sortedSetJson(set)] = typeof resp.serialize === "function" ?
 				resp.serialize() : resp;
 			canWait.data({ pageData: data });
 			return resp;
-		});
+		}, false));
 	}
 	return promise;
 }


### PR DESCRIPTION
The **canWait** global creates a callback function that waits within the
request lifecycle. We need to use this because can-connect brings in its
own Promise polyfill. So the first time on the server data is added to
a canWait request the Promise wrapper won't wrap can-connect's promises.
The second time it will (because it will be the global Promise at that
		point). So we can use a **canWait** callback that will tap into
the lifecycle.