### PR TITLE
combine-requests should reject when getListData rejects

### DIFF
--- a/src/data/combine-requests/combine-requests.js
+++ b/src/data/combine-requests/combine-requests.js
@@ -227,12 +227,19 @@ module.exports = connect.behavior("data-combine-requests",function(base){
 						forEach.call(combinedData, function(combined){
 
 							base.getListData(combined.set).then(function(data){
-
 								if(combined.pendingRequests.length === 1) {
 									combined.pendingRequests[0].deferred.resolve(data);
 								} else {
 									forEach.call(combined.pendingRequests, function(pending){
 										pending.deferred.resolve( {data: self.getSubset(pending.set, combined.set, getItems(data) )} );
+									});
+								}
+							}, function(err){
+								if(combined.pendingRequests.length === 1) {
+									combined.pendingRequests[0].deferred.reject(err);
+								} else {
+									forEach.call(combined.pendingRequests, function(pending){
+										pending.deferred.reject(err);
 									});
 								}
 

--- a/src/data/combine-requests/combine-requests_test.js
+++ b/src/data/combine-requests/combine-requests_test.js
@@ -89,3 +89,20 @@ QUnit.test("ranges", function(){
 
 
 });
+
+QUnit.test("Rejects when getListData rejects", function(){
+	stop();
+
+	var res = combineRequests({
+		getListData: function(){
+			return Promise.reject(new Error("didn't work"));
+		}
+	});
+
+	var promise = res.getListData({start: 0, end: 3});
+
+	promise.then(null, function(err){
+		equal(err.message, "didn't work", "promise was rejected");
+		start();
+	});
+});

--- a/src/data/combine-requests/test.html
+++ b/src/data/combine-requests/test.html
@@ -1,0 +1,3 @@
+<title>can-connect tests</title>
+<script src="../../../node_modules/steal/steal.js" main="src/data/combine-requests/combine-requests_test"></script>
+<div id="qunit-fixture"></div>

--- a/src/helpers/wait.js
+++ b/src/helpers/wait.js
@@ -24,14 +24,18 @@ function sortedSetJson(set){
 // server side rendering.
 function addToCanWaitData(promise, name, set){
 	if(typeof canWait !== "undefined" && canWait.data) {
-		return promise.then(canWait(function(resp){
+		var addToData = canWait(function(resp){
 			var data = {};
 			var keyData = data[name] = {};
 			keyData[sortedSetJson(set)] = typeof resp.serialize === "function" ?
 				resp.serialize() : resp;
 			canWait.data({ pageData: data });
 			return resp;
-		}, false));
+		});
+
+		promise.then(null, addToData);
+
+		return promise.then(addToData);
 	}
 	return promise;
 }


### PR DESCRIPTION
If one of the getListData requests rejected we would never get a
rejection of the combine-request promise. Combined with can-wait this
means that pages could be prevented from loading.