### PR TITLE
Fix typos causing errors

### DIFF
--- a/src/data/localstorage-cache/localstorage-cache.js
+++ b/src/data/localstorage-cache/localstorage-cache.js
@@ -335,7 +335,7 @@ module.exports = connect.behavior("data-localstorage-cache",function(baseConnect
 			if(res){
 				return Promise.resolve( JSON.parse(res) );
 			} else {
-				return new Promise.reject({message: "no data", error: 404});
+				return Promise.reject({message: "no data", error: 404});
 			}
 		},
 

--- a/src/fall-through-cache/fall-through-cache.js
+++ b/src/fall-through-cache/fall-through-cache.js
@@ -262,7 +262,7 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 							self.updatedInstance(instance, instanceData2);
 							self.deleteInstanceReference(instance);
 
-						}, function(){
+						}, function(e){
 							// what do we do here?  self.rejectedUpdatedList ?
 							console.log("REJECTED", e);
 						});


### PR DESCRIPTION
This fixes #63 and #67 which are errors caused by typos. I didn't determine that it was worth writing tests, as the errors were not functional errors.