### PR TITLE
Set always "X-Requested-With" header

### DIFF
--- a/src/helpers/ajax.js
+++ b/src/helpers/ajax.js
@@ -101,6 +101,9 @@ module.exports = function (o) {
 		data = isJson ? JSON.stringify(o.data) : $._formData(o.data);
 		xhr.setRequestHeader("Content-Type", isJson ? "application/json" : "application/x-www-form-urlencoded");
 	}
+	
+	// X-Requested-With header
+    xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest" );
 
 	xhr.send(data);
 	return deferred.promise;


### PR DESCRIPTION
in supermap we use the jquery ajax methods.
but without supermap this makeAjax helper will serve the xhr object.
currently the `X-Requested-With` header is not set.

for security reason we always have to set `X-Requested-With`
see http://stackoverflow.com/a/22533680