### PR TITLE
Use can-observation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "can-list": "^3.0.0-pre.1",
     "can-map": "^3.0.0-pre.2",
     "can-event": "^3.0.0-pre.3",
-    "can-observe-info": "^3.0.0-pre.5",
+    "can-observation": "^3.0.0-pre.0",
     "can-set": "^0.6.0-pre.3",
     "can-stache": "^3.0.0-pre.1",
     "can-stache-bindings": "^3.0.0-pre.1",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,16 @@
   "description": "Data connection middleware and utilities",
   "main": "can-connect.js",
   "dependencies": {
-    "can-compute": "^3.0.0-pre.2",
-    "can-define": "^0.7.5",
-    "can-list": "^3.0.0-pre.1",
-    "can-map": "^3.0.0-pre.2",
+    "can-compute": "^3.0.0-pre.5",
+    "can-list": "^3.0.0-pre.4",
+    "can-map": "^3.0.0-pre.7",
     "can-event": "^3.0.0-pre.3",
     "can-observation": "^3.0.0-pre.0",
     "can-set": "^0.6.0-pre.3",
-    "can-stache": "^3.0.0-pre.1",
-    "can-stache-bindings": "^3.0.0-pre.1",
-    "can-util": "^3.0.0-pre.14",
-    "can-view-callbacks": "^3.0.0-pre.1",
+    "can-stache": "^3.0.0-pre.8",
+    "can-stache-bindings": "^3.0.0-pre.5",
+    "can-util": "^3.0.0-pre.28",
+    "can-view-callbacks": "^3.0.0-pre.4",
     "can-view-nodelist": "^3.0.0-pre.1",
     "jquery": "^2.1.4",
     "steal-stache": "^3.0.0-pre.1",
@@ -25,7 +24,7 @@
     "url": "https://github.com/canjs/can-connect.git"
   },
   "devDependencies": {
-    "can-define": "^0.6.3",
+    "can-define": "^0.7.7",
     "can-fixture": "^0.1.0",
     "can-wait": "^0.2.0",
     "documentjs": "^0.4.4",
@@ -50,7 +49,8 @@
     "npmDependencies": [
       "steal-qunit",
       "can-fixture",
-      "can-wait"
+      "can-wait",
+	  "can-define"
     ],
     "directories": {
       "lib": "src"

--- a/src/can/map/map.js
+++ b/src/can/map/map.js
@@ -4,7 +4,7 @@ var each = require("can-util/js/each/each");
 var connect = require("can-connect");
 var canBatch = require("can-event/batch/batch");
 var canEvent = require("can-event");
-var ObserveInfo = require("can-observe-info");
+var Observation = require("can-observation");
 
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var isArray = require("can-util/js/is-array/is-array");
@@ -74,7 +74,7 @@ module.exports = connect.behavior("can-map",function(baseConnect){
 					ids.push(readObservabe(instance,"id"));
 				}
 
-				// Use `__get` instead of `attr` for performance. (But that means we have to remember to call `ObserveInfo.observe`.)
+				// Use `__get` instead of `attr` for performance. (But that means we have to remember to call `Observation.add`.)
 				return ids.length > 1 ? ids.join("@|@"): ids[0];
 			} else {
 				return baseConnect.id(instance);
@@ -483,7 +483,7 @@ var mapOverwrites = {	// ## can.Model#bind and can.Model#unbind
 		 *   @return {Boolean}
 		 */
 		return function () {
-			ObserveInfo.observe(this,"_saving");
+			Observation.add(this,"_saving");
 			return !!getExpando(this, "_saving");
 		};
 	},
@@ -501,7 +501,7 @@ var mapOverwrites = {	// ## can.Model#bind and can.Model#unbind
 		 *   @return {Boolean}
 		 */
 		return function () {
-			ObserveInfo.observe(this,"_destroying");
+			Observation.add(this,"_destroying");
 			return !!getExpando(this, "_destroying");
 		};
 	},
@@ -649,14 +649,14 @@ var listStaticOverwrites = {
 var readObservabe = function(instance, prop){
 	if("__get" in instance) {
 		if(callCanReadingOnIdRead) {
-			ObserveInfo.observe(instance, prop);
+			Observation.add(instance, prop);
 		}
 		return instance.__get(prop);
 	} else {
 		if(callCanReadingOnIdRead) {
 			return instance[prop];
 		} else {
-			return ObserveInfo.notObserve(function(){
+			return Observation.ignore(function(){
 				return instance[prop];
 			})();
 		}

--- a/src/can/model/model.js
+++ b/src/can/model/model.js
@@ -7,7 +7,7 @@ var $ = require("jquery"),
 	parseData = require("../../data/parse/"),
 	CanMap = require("can-map"),
 	CanList = require("can-list"),
-	ObserveInfo = require("can-observe-info"),
+	Observation = require("can-observation"),
 	canEvent = require("can-event");
 
 var each = require("can-util/js/each/each");
@@ -40,15 +40,15 @@ var mapBehavior = connect.behavior(function(baseConnect){
 			var idProp = inst.constructor.id || "id";
 			if(inst instanceof CanMap) {
 				if(callCanReadingOnIdRead) {
-					ObserveInfo.observe(inst, idProp);
+					Observation.add(inst, idProp);
 				}
-				// Use `__get` instead of `attr` for performance. (But that means we have to remember to call `ObserveInfo.reading`.)
+				// Use `__get` instead of `attr` for performance. (But that means we have to remember to call `Observation.reading`.)
 				return inst.__get(idProp);
 			} else {
 				if(callCanReadingOnIdRead) {
 					return inst[idProp];
 				} else {
-					return ObserveInfo.notObserve(function(){
+					return Observation.ignore(function(){
 						return inst[idProp];
 					});
 				}

--- a/src/can/model/model_test.js
+++ b/src/can/model/model_test.js
@@ -8,7 +8,7 @@ var makeDeferred = require("can-connect/helpers/deferred");
 var canEvent = require("can-event");
 var CanMap = require("can-map");
 var CanList = require("can-list");
-var ObserveInfo = require("can-observe-info");
+var Observation = require("can-observation");
 
 var assign = require("can-util/js/assign/assign");
 
@@ -704,8 +704,8 @@ var logErrorAndStart = function(e){
 	});
 	test('uses attr with isNew', function () {
 		// TODO this does not seem to be consistent expect(2);
-		var old = ObserveInfo.observe;
-		ObserveInfo.observe = function (object, attribute) {
+		var old = Observation.add;
+		Observation.add = function (object, attribute) {
 			if (attribute === 'id') {
 				ok(true, 'used attr');
 			}
@@ -715,7 +715,7 @@ var logErrorAndStart = function(e){
 			id: 4
 		});
 		m.isNew();
-		ObserveInfo.observe = old;
+		Observation.add = old;
 	});
 
 	test('extends defaults by calling base method', function () {

--- a/src/can/tag/tag.js
+++ b/src/can/tag/tag.js
@@ -37,7 +37,7 @@ var connect = require("can-connect");
 var compute = require('can-compute');
 var expression = require("can-stache/src/expression");
 var viewCallbacks = require("can-view-callbacks");
-var ObserveInfo = require("can-observe-info");
+var Observation = require("can-observation");
 var nodeLists = require("can-view-nodelist");
 var canEvent = require("can-event");
 
@@ -82,7 +82,7 @@ connect.tag = function(tagName, connection){
 
 
 		var addedToPageData = false;
-		var addToPageData = ObserveInfo.notObserve(function(set, promise){
+		var addToPageData = Observation.ignore(function(set, promise){
 			if(!addedToPageData) {
 				var root = tagData.scope.attr("%root") || tagData.scope.attr("@root");
 				if( root && root.pageData ) {


### PR DESCRIPTION
This updates can-connect to use can-observation instead of can-observe-info. Also update dependencies that use can-observation, as it's a singleton.