### PR TITLE
Add can-connect/can/model to namespace

### DIFF
--- a/src/can/model/model.js
+++ b/src/can/model/model.js
@@ -8,7 +8,8 @@ var $ = require("jquery"),
 	CanMap = require("can-map"),
 	CanList = require("can-list"),
 	Observation = require("can-observation"),
-	canEvent = require("can-event");
+	canEvent = require("can-event"),
+	ns = require("can-util/namespace");
 
 var each = require("can-util/js/each/each");
 var dev = require("can-util/js/dev/dev");
@@ -344,5 +345,9 @@ CanModel.List = CanList.extend({
 		}
 	}
 });
+
+if(!ns.Model) {
+	ns.Model = CanModel;
+}
 
 module.exports = CanModel;


### PR DESCRIPTION
This makes it so that can-connect/can/model/ is added to the
can-util/namespace *only* if there isn't already a Model on the
namespace. can-model will **always** be added to the namespace. In this
way, can-connect/can/model/ acts as a fallback only when can-model isn't
already loaded.

This is for the can/legacy changes.