### PR TITLE
Specify npm version in engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,9 @@
   "keywords": [
     "CanJS"
   ],
+  "engines": {
+    "npm": "^3.0.0"
+  },
   "author": "Bitovi",
   "license": "MIT"
 }


### PR DESCRIPTION
Closes #142 

It doesn't work as I was expecting, but if you set `engine-strict` config flag the installation will fail, otherwise the field is advisory only.

![tumblr_lgedv2vtt21qf4x93o1_40020110725-22047-38imqt](https://cloud.githubusercontent.com/assets/724877/18110191/ce378086-6eec-11e6-9c5a-574686129d00.jpg)
