### PR TITLE
can/base-map implementation

### DIFF
--- a/can/base-map/base-map.js
+++ b/can/base-map/base-map.js
@@ -14,7 +14,7 @@ var callbacksOnce = require("../../constructor/callbacks-once/");
 
 var $ = require("jquery");
 
-connect.superMap = function(options){
+connect.baseMap = function(options){
 
 	var behaviors = [
 		constructor,
@@ -36,4 +36,4 @@ connect.superMap = function(options){
 	return connect(behaviors,options);
 };
 
-module.exports = connect.superMap;
+module.exports = connect.baseMap;

--- a/can/base-map/base-map.js
+++ b/can/base-map/base-map.js
@@ -1,0 +1,39 @@
+var connect = require("can-connect");
+
+var constructor = require("../../constructor/");
+var canMap = require("../map/");
+var canRef = require("../ref/");
+var constructorStore = require("../../constructor/store/");
+var dataCallbacks = require("../../data/callbacks/");
+var callbacksCache = require("../../data/callbacks-cache/");
+var dataParse = require("../../data/parse/");
+var dataUrl = require("../../data/url/");
+var realTime = require("../../real-time/");
+var callbacksOnce = require("../../constructor/callbacks-once/");
+
+
+var $ = require("jquery");
+
+connect.superMap = function(options){
+
+	var behaviors = [
+		constructor,
+		canMap,
+		canRef,
+		constructorStore,
+		dataCallbacks,
+		dataParse,
+		dataUrl,
+		realTime,
+		callbacksOnce
+	];
+
+	// Handles if jQuery isn't provided.
+	if($ && $.ajax) {
+		options.ajax = $.ajax;
+	}
+	
+	return connect(behaviors,options);
+};
+
+module.exports = connect.superMap;

--- a/can/base-map/base-map.md
+++ b/can/base-map/base-map.md
@@ -1,0 +1,70 @@
+@module {function} can-connect/can/super-map/super-map
+@parent can-connect.modules
+
+Create connection with many of the best behaviors in can-connect and hook it up to
+a [can.Map](http://canjs.com/docs/can.Map.html).
+
+@signature `superMap(options)`
+
+  Creates a connection with the following behaviors: [can-connect/constructor/constructor],
+  [can-connect/can/map/map],
+  [can-connect/constructor/store/store],
+  [can-connect/data/callbacks/callbacks],
+  [can-connect/data/callbacks-cache/callbacks-cache],
+  [can-connect/data/combine-requests/combine-requests],
+  [can-connect/data/inline-cache/inline-cache],
+  [can-connect/data/parse/parse],
+  [can-connect/data/url/url],
+  [can-connect/real-time/real-time],
+  [can-connect/fall-through-cache/fall-through-cache],
+  [can-connect/constructor/callbacks-once/callbacks-once].
+
+  And creates a [can-connect/data/localstorage-cache/localstorage-cache] to use as a [can-connect/base/base.cacheConnection].
+
+@body
+
+## Use
+
+The `can-connect/can/super-map` module exports a helper function that creates a connection
+with the "standard" behaviors in can-connect and hooks it up to a
+[can.Map](http://canjs.com/docs/can.Map.html) and [can.List](http://canjs.com/docs/can.List.html).
+
+If you are using CanJS, this is an easy way to create a connection that can be useful and
+fast in most circumstances.
+
+To use it, first define a Map and List constructor function:
+
+```
+var Todo = can.Map.extend({ ... });
+var TodoList = can.List.extend({Map: Todo},{ ... });
+```
+
+Next, call `superMap` with all of the options needed by the behaviors that `superMap` adds:
+
+```
+var todoConnection = superMap({
+  idProp: "_id",
+  Map: Todo,
+  List: TodoList,
+  url: "/services/todos",
+  name: "todo"
+});
+```
+
+As, [can-connect/can/map/map] adds CRUD methods to the `Map` option, you can use those to create,
+read, update and destroy todos:
+
+```
+Todo.getList({}).then(function(todos){ ... });
+Todo.get({}).then(function(todo){ ... });
+
+new Todo({name: "dishes"}).save().then(function(todo){
+  todo.attr({
+      name: "Do the dishes"
+    })
+    .save()
+    .then(function(todo){
+      todo.destroy();
+    });
+});
+```

--- a/can/base-map/base-map.md
+++ b/can/base-map/base-map.md
@@ -1,31 +1,26 @@
-@module {function} can-connect/can/super-map/super-map
+@module {function} can-connect/can/base-map/base-map
 @parent can-connect.modules
 
 Create connection with many of the best behaviors in can-connect and hook it up to
 a [can.Map](http://canjs.com/docs/can.Map.html).
 
-@signature `superMap(options)`
+@signature `baseMap(options)`
 
   Creates a connection with the following behaviors: [can-connect/constructor/constructor],
   [can-connect/can/map/map],
   [can-connect/constructor/store/store],
   [can-connect/data/callbacks/callbacks],
   [can-connect/data/callbacks-cache/callbacks-cache],
-  [can-connect/data/combine-requests/combine-requests],
-  [can-connect/data/inline-cache/inline-cache],
   [can-connect/data/parse/parse],
   [can-connect/data/url/url],
   [can-connect/real-time/real-time],
-  [can-connect/fall-through-cache/fall-through-cache],
   [can-connect/constructor/callbacks-once/callbacks-once].
-
-  And creates a [can-connect/data/localstorage-cache/localstorage-cache] to use as a [can-connect/base/base.cacheConnection].
 
 @body
 
 ## Use
 
-The `can-connect/can/super-map` module exports a helper function that creates a connection
+The `can-connect/can/base-map` module exports a helper function that creates a connection
 with the "standard" behaviors in can-connect and hooks it up to a
 [can.Map](http://canjs.com/docs/can.Map.html) and [can.List](http://canjs.com/docs/can.List.html).
 
@@ -39,10 +34,10 @@ var Todo = can.Map.extend({ ... });
 var TodoList = can.List.extend({Map: Todo},{ ... });
 ```
 
-Next, call `superMap` with all of the options needed by the behaviors that `superMap` adds:
+Next, call `baseMap` with all of the options needed by the behaviors that `baseMap` adds:
 
 ```
-var todoConnection = superMap({
+var todoConnection = baseMap({
   idProp: "_id",
   Map: Todo,
   List: TodoList,

--- a/can/base-map/base-map_test.js
+++ b/can/base-map/base-map_test.js
@@ -1,0 +1,57 @@
+var QUnit = require("steal-qunit");
+var fixture = require("can-fixture");
+var Map = require("can-map");
+var baseMap = require("can-connect/can/base-map/");
+
+QUnit.module("can-connect/can/base-map");
+
+QUnit.test("uses idProp", function(){
+
+	var Restaurant = Map.extend({});
+
+	var connection = baseMap({
+		url: "/api/restaurants",
+		idProp: '_id',
+		Map: Restaurant,
+		List: Restaurant.List,
+		name: "restaurant"
+	});
+
+	fixture({
+		"GET /api/restaurants/{_id}": function(request){
+			return {id: 5};
+		}
+	});
+
+	stop();
+	connection.getData({_id: 5}).then(function(data){
+		deepEqual(data, {id: 5}, "findOne");
+		start();
+	});
+
+
+});
+
+
+QUnit.test("creates map if none is provided (#8)", function(){
+
+	var connection = baseMap({
+		url: "/api/restaurants",
+		idProp: '_id',
+		name: "restaurant"
+	});
+
+	fixture({
+		"GET /api/restaurants/{_id}": function(request){
+			return {id: 5};
+		}
+	});
+
+	stop();
+	connection.getData({_id: 5}).then(function(data){
+		deepEqual(data, {id: 5}, "findOne");
+		start();
+	});
+
+
+});

--- a/can/test.js
+++ b/can/test.js
@@ -4,4 +4,5 @@ require("./map/define-map-test");
 require("./model/model_test");
 require("./ref/ref-test");
 require("./super-map/super-map_test");
+require("./base-map/base-map_test");
 require("./tag/tag_test");


### PR DESCRIPTION
CanJS base-map is a scaled down version of supermap without the caching and request combination layer.