### PR TITLE
Fixes #133, creates API for Maps and Lists for consistent data checking

### DIFF
--- a/fall-through-cache/fall-through-cache.js
+++ b/fall-through-cache/fall-through-cache.js
@@ -3,7 +3,7 @@
  * @parent can-connect.behaviors
  * @group can-connect/fall-through-cache/fall-through-cache.data Data Callbacks
  * @group can-connect/fall-through-cache/fall-through-cache.hydrators Hydrators
- * @group can-connect/fall-through-cache/fall-through-cache.mixins can/map Mixins
+ * @group can-connect/fall-through-cache/fall-through-cache.mixins mixins Mixins
  *
  * A fall through cache that checks another `cacheConnection`.
  *

--- a/fall-through-cache/fall-through-cache.js
+++ b/fall-through-cache/fall-through-cache.js
@@ -129,6 +129,8 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 			if(this.Map) {
 				addIsConsistent(this, this.Map);
 			}
+
+			baseConnect.init.apply(this, arguments);
 		},
 		_setIsConsistent: function(instance, isConsistent) {
 			if(instance._setIsConsistent) {

--- a/fall-through-cache/fall-through-cache.js
+++ b/fall-through-cache/fall-through-cache.js
@@ -3,7 +3,7 @@
  * @parent can-connect.behaviors
  * @group can-connect/fall-through-cache/fall-through-cache.data Data Callbacks
  * @group can-connect/fall-through-cache/fall-through-cache.hydrators Hydrators
- * @group can-connect/fall-through-cache/fall-through-cache.can-map can/map Mixins
+ * @group can-connect/fall-through-cache/fall-through-cache.mixins can/map Mixins
  *
  * A fall through cache that checks another `cacheConnection`.
  *
@@ -123,18 +123,19 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 					canEvent.dispatch.call(this, "_isConsistent", [isConsistent, !isConsistent]);
 				};
 			},
-      /* 
+      /**
        * @function can-connect/fall-through-cache/fall-through-cache.isConsistent isConsistent
-       * @parent can-connect/fall-through-cache/fall-through-cache.can-map
+       * @parent can-connect/fall-through-cache/fall-through-cache.mixins
        *
        * Returns whether or not the data is consistent between the server and 
        * the fall-through-cache data.
        *
-       * @signature `map.isConsistent()` or `list.isConsistent()`
+       * @signature `[map|list].isConsistent()`
        *
        *   Returns true if the data has been successfully returned from the 
        *   server and in sync with the fall-through-cache. Returns false if the
        *   data is from the cache.
+       *   
        *   @return {Boolean}
        */
 			isConsistent: function(base, connection) {
@@ -143,17 +144,18 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 		    	return !!getExpando(this, "_isConsistent");
 				};
 			}
-      /* 
+      /**
        * @function can-connect/fall-through-cache/fall-through-cache.inconsistencyReason inconsistencyReason
-       * @parent can-connect/fall-through-cache/fall-through-cache.can-map
+       * @parent can-connect/fall-through-cache/fall-through-cache.mixins
        *
        * Returns the error of the AJAX call from the base data layer.
        *
-       * @signature `map.inconsistencyReason` or `list.inconsistencyReason`
+       * @signature `[map|list].inconsistencyReason`
        *
        *   Returns the error fo the base data layer's AJAX call if it's promise
        *   was rejected. If there isn't an inconsistency issue between the server
        *   and fall-through-cache layer, this will be undefined.
+       *   
        *   @return {Object}
        */
 		});

--- a/fall-through-cache/fall-through-cache.js
+++ b/fall-through-cache/fall-through-cache.js
@@ -123,8 +123,12 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 
 	var behavior = {
 		init: function() {
-			this.List && addIsConsistent(this, this.List);
-			this.Map && addIsConsistent(this, this.Map);
+			if(this.List) {
+				addIsConsistent(this, this.List);
+			}
+			if(this.Map) {
+				addIsConsistent(this, this.Map);
+			}
 		},
 		_setIsConsistent: function(instance, isConsistent) {
 			if(instance._setIsConsistent) {
@@ -212,10 +216,10 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 
 					setTimeout(function(){
 						baseConnect.getListData.call(self, set).then(function(listData){
-;
+
 							self.cacheConnection.updateListData(listData, set);
 							self.updatedList(list, listData, set);
-							self._setIsConsistent(list, true)
+							self._setIsConsistent(list, true);
 							self.deleteListReference(list, set);
 
 						}, function(e){
@@ -312,7 +316,7 @@ module.exports = connect.behavior("fall-through-cache",function(baseConnect){
 				self._getMakeInstance(self.id(instanceData) || self.id(params), function(instance){
 					self.addInstanceReference(instance);
 
-					self._setIsConsistent(instance, false)
+					self._setIsConsistent(instance, false);
 
 					setTimeout(function(){
 						baseConnect.getData.call(self, params).then(function(instanceData2){


### PR DESCRIPTION
If `can/map` is being used alongside `fall-through-cache`, new attributes will be added to `Map`s and `List`s.

- `isConsistent()` will return true if the data is actively in sync with the data from the server, false if it's relying on `fall-back-cache`'s cached data.
- `inconsistencyReason` will return the base connection's rejected promise error, should there be one.