### PR TITLE
Adding a fallback to the steal.js script

### DIFF
--- a/constructor/tests/wait.html
+++ b/constructor/tests/wait.html
@@ -3,66 +3,70 @@
 	window.removeMyself = window.parent.removeMyself;
 </script>
 
-<script src="../../node_modules/steal/steal.js" main="@empty">
-	var wait = require("can-wait");
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../../../node_modules/steal/steal.js" main="@empty"></script>
+<script>
+	steal.done().then(function(){
+		System.import("can-wait").then(function(wait){
+			function hasQUnit() {
+				return typeof QUnit !== "undefined";
+			}
 
-	function hasQUnit() {
-		return typeof QUnit !== "undefined";
-	}
+			wait(function(){
+				Promise.all([
+					System["import"]("can-connect/constructor/"),
+					System["import"]("can-connect/data/url/"),
+					System["import"]("can-connect/can-connect"),
+					System["import"]("can-set"),
+					System["import"]("can-fixture"),
+					System["import"]("can-util/js/assign/assign")
+				]).then(function(mods){
+					var constructor = mods[0];
+					var persist = mods[1];
+					var connect = mods[2];
+					var canSet = mods[3];
+					var fixture = mods[4];
+					var assign = mods[5]
 
-	wait(function(){
-		Promise.all([
-			System["import"]("can-connect/constructor/"),
-			System["import"]("can-connect/data/url/"),
-			System["import"]("can-connect/can-connect"),
-			System["import"]("can-set"),
-			System["import"]("can-fixture"),
-			System["import"]("can-util/js/assign/assign")
-		]).then(function(mods){
-			var constructor = mods[0];
-			var persist = mods[1];
-			var connect = mods[2];
-			var canSet = mods[3];
-			var fixture = mods[4];
-			var assign = mods[5]
+					var Todo = function(values){
+						assign(this, values);
+					};
+					var TodoList = function(todos){
+						var listed = todos.slice(0);
+						listed.isList = true;
+						return listed;
+					};
+					var connection = constructor( persist( connect.base({
+						instance: function(values){
+							return new Todo(values);
+						},
+						list: function(arr){
+							return new TodoList(arr.data);
+						},
+						url: "/constructor/todos",
+						name: "todos"
+					}) ));
 
-			var Todo = function(values){
-				assign(this, values);
-			};
-			var TodoList = function(todos){
-				var listed = todos.slice(0);
-				listed.isList = true;
-				return listed;
-			};
-			var connection = constructor( persist( connect.base({
-				instance: function(values){
-					return new Todo(values);
-				},
-				list: function(arr){
-					return new TodoList(arr.data);
-				},
-				url: "/constructor/todos",
-				name: "todos"
-			}) ));
+					fixture({
+						"GET /constructor/todos/2": function(req) {
+							return [{id:2}];
+						}
+					});
 
-			fixture({
-				"GET /constructor/todos/2": function(req) {
-					return [{id:2}];
+					connection.get({ id: 2 });
+				});
+			}).then(function(responses){
+				if(hasQUnit()) {
+					QUnit.equal(responses.length, 1, "There was one piece of data added");
+					QUnit.ok(responses[0].pageData.todos, "data added to the response");
+
+					removeMyself();
+				} else {
+					console.log("responses", responses);
 				}
+			}, function(errors){
+				console.error("oh noes", errors);
 			});
-
-			connection.get({ id: 2 });
 		});
-	}).then(function(responses){
-		if(hasQUnit()) {
-			QUnit.equal(responses.length, 1, "There was one piece of data added");
-			QUnit.ok(responses[0].pageData.todos, "data added to the response");
-
-			removeMyself();
-		} else {
-			console.log("responses", responses);
-		}
-	}, function(errors){
-		console.error("oh noes", errors);
 	});
 </script>


### PR DESCRIPTION
When this test runs in canjs/canjs, the steal.js script is not located
in the same place. This adds a fallback to the script location. It is
also updated to use `steal.done()` and `System.import` since the code is no
longer in the steal.js script body, so it cannot use `require`.

Part of https://github.com/canjs/canjs/issues/2527.