### PR TITLE
Fix can-connect/all

### DIFF
--- a/all.js
+++ b/all.js
@@ -1,4 +1,4 @@
-var connect = window.connect = require("./can-connect");
+var connect = require("./can-connect");
 
 connect.cacheRequests = require("./cache-requests/");
 
@@ -19,3 +19,5 @@ connect.realTime = require("./real-time/");
 connect.superMap = require("./can/super-map/");
 connect.tag = require("./can/tag/");
 connect.baseMap = require('./can/base-map/');
+
+module.exports = connect;

--- a/core_test.js
+++ b/core_test.js
@@ -20,3 +20,29 @@ QUnit.test("Determine .id() from algebra (#82)", function(){
 	QUnit.equal( connection.id({_id: "foo"}), "foo", "got id from algebra");
 	QUnit.equal( connection.id({_id: 1}), 1, "got id from algebra");
 });
+
+QUnit.test("Everything available at can-connect/all", function(){
+	var all = require("can-connect/all");
+	var expectedBehaviors = [
+		'cacheRequests',
+		'constructor',
+		'constructorCallbacksOnce',
+		'constructorStore',
+		'dataCallbacks',
+		'dataCallbacksCache',
+		'dataCombineRequests',
+		'dataInlineCache',
+		'dataLocalStorageCache',
+		'dataMemoryCache',
+		'dataParse',
+		'dataUrl',
+		'fallThroughCache',
+		'realTime',
+		'superMap',
+		'tag',
+		'baseMap',
+	];
+	expectedBehaviors.forEach(function(behaviorName){
+		QUnit.ok(all[behaviorName], 'behavior in place: ' + behaviorName);
+	});
+});


### PR DESCRIPTION
This removes the `window.connect` global from can-connect/all and exports the module.