### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "can-util": "^3.0.13",
     "can-view-callbacks": "^3.0.2",
     "can-view-nodelist": "^3.0.2",
-    "jquery": "^3.1.1",
+    "jquery": "2.x - 3.x",
     "steal-stache": "^3.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,32 +4,32 @@
   "description": "Data connection middleware and utilities",
   "main": "can-connect.js",
   "dependencies": {
-    "can-compute": "^3.0.0",
-    "can-define": "^1.0.0",
+    "can-compute": "^3.0.4",
+    "can-define": "^1.0.5",
     "can-event": "^3.0.1",
-    "can-list": "^3.0.0",
-    "can-map": "^3.0.1",
-    "can-observation": "^3.0.1",
-    "can-set": "^1.0.0",
-    "can-stache": "^3.0.1",
-    "can-stache-bindings": "^3.0.0",
-    "can-util": "^3.0.1",
-    "can-view-callbacks": "^3.0.0",
-    "can-view-nodelist": "^3.0.0",
-    "jquery": "^2.1.4",
-    "steal-stache": "^3.0.0"
+    "can-list": "^3.0.1",
+    "can-map": "^3.0.3",
+    "can-observation": "^3.0.3",
+    "can-set": "^1.0.2",
+    "can-stache": "^3.0.13",
+    "can-stache-bindings": "^3.0.5",
+    "can-util": "^3.0.13",
+    "can-view-callbacks": "^3.0.2",
+    "can-view-nodelist": "^3.0.2",
+    "jquery": "^3.1.1",
+    "steal-stache": "^3.0.3"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/canjs/can-connect.git"
   },
   "devDependencies": {
-    "can-fixture": "^0.1.0",
-    "jshint": "^2.9.1",
-    "steal": "^0.15.8",
-    "steal-qunit": "^0.1.3",
-    "steal-tools": "^0.15.5",
-    "testee": "^0.2.5"
+    "can-fixture": "^1.0.10",
+    "jshint": "^2.9.4",
+    "steal": "^0.16.43",
+    "steal-qunit": "^0.1.4",
+    "steal-tools": "^0.16.8",
+    "testee": "^0.3.0"
   },
   "system": {
     "ignoreBrowser": true,


### PR DESCRIPTION
Simple dependency update courtesy of [npm-check-updates](https://www.npmjs.com/package/npm-check-updates)

jQuery 3.1.1 & can-fixture are the only major updates, but pass tests as is.