### PR TITLE
Custom update 223

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -277,18 +277,6 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		}
 	};
 
-	// Customize ~Instance actions:
-	var customAction = {
-		// @return Boolean Whether to skip the regular update actions.
-		updatedInstance: function(){
-			if (this.updateMap){
-				this.updateMap.apply(this, arguments);
-				return true;
-			}
-			return false;
-		}
-	};
-
 	each([
 		/**
 		 * @function can-connect/can/map/map.createdInstance createdInstance
@@ -315,6 +303,9 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		 *
 		 *   Updates the instance with `props` and dispatches a
 		 *   "updated" event on the map and the map's constructor function.
+		 *
+		 * The update action can be customized by providing connection with `updatedMap` option which
+		 * takes the same two arguments.
 		 */
 		"updated",
 		/**
@@ -334,13 +325,12 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		behavior[funcName+"Instance"] = function (instance, props) {
 			var constructor = instance.constructor;
 
-			var skipUpdate = false;
-			if (customAction[funcName + "Instance"]){
-				skipUpdate = customAction[funcName + "Instance"](instance, props);
-			}
+			if (typeof this[funcName + 'Map'] === 'function'){
+				instance = this[funcName + 'Map'](instance, props);
 
-			// Update attributes if attributes have been passed
-			if(!skipUpdate && props && typeof props === 'object') {
+			} else if(props && typeof props === 'object') {
+				// Update attributes if attributes have been passed
+
 				if("set" in instance) {
 					instance.set(isFunction(props.get) ? props.get() : props, this.constructor.removeAttr || false);
 				} else if("attr" in instance) {

--- a/can/map/map.js
+++ b/can/map/map.js
@@ -305,7 +305,15 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		 *   "updated" event on the map and the map's constructor function.
 		 *
 		 * The update action can be customized by providing connection with `updatedMap` option which
-		 * takes the same two arguments.
+		 * takes the same two arguments:
+		 *
+		 * ```
+		 * connect( [ canMap ], {
+		 *     updatedMap: function( instance, props ){
+		 *         return smartMerge( instance, props );
+		 *     }
+		 * } )
+		 * ```
 		 */
 		"updated",
 		/**

--- a/can/map/map.js
+++ b/can/map/map.js
@@ -299,7 +299,7 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		 *
 		 * Updates the instance with the response from [can-connect/connection.updateData].
 		 *
-		 * @signature `connection.createdInstance( instance, props )`
+		 * @signature `connection.updatedInstance( instance, props )`
 		 *
 		 *   Updates the instance with `props` and dispatches a
 		 *   "updated" event on the map and the map's constructor function.

--- a/can/map/map.js
+++ b/can/map/map.js
@@ -277,6 +277,18 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		}
 	};
 
+	// Customize ~Instance actions:
+	var customAction = {
+		// @return Boolean Whether to execute the regular update actions.
+		updatedInstance: function(){
+			if (this.updateMap){
+				this.updateMap.apply(this, arguments);
+				return false;
+			}
+			return true;
+		}
+	};
+
 	each([
 		/**
 		 * @function can-connect/can/map/map.createdInstance createdInstance
@@ -322,8 +334,13 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 		behavior[funcName+"Instance"] = function (instance, props) {
 			var constructor = instance.constructor;
 
+			var skipUpdate = false;
+			if (customAction[funcName + "Instance"]){
+				skipUpdate = customAction[funcName + "Instance"](instance, props);
+			}
+
 			// Update attributes if attributes have been passed
-			if(props && typeof props === 'object') {
+			if(!skipUpdate && props && typeof props === 'object') {
 				if("set" in instance) {
 					instance.set(isFunction(props.get) ? props.get() : props, this.constructor.removeAttr || false);
 				} else if("attr" in instance) {

--- a/can/map/map.js
+++ b/can/map/map.js
@@ -279,13 +279,13 @@ module.exports = connect.behavior("can/map",function(baseConnection){
 
 	// Customize ~Instance actions:
 	var customAction = {
-		// @return Boolean Whether to execute the regular update actions.
+		// @return Boolean Whether to skip the regular update actions.
 		updatedInstance: function(){
 			if (this.updateMap){
 				this.updateMap.apply(this, arguments);
-				return false;
+				return true;
 			}
-			return true;
+			return false;
 		}
 	};
 


### PR DESCRIPTION
To customize `updatedInstance` callback of can/map/map we can provide `updateMap` option:
```js
connect( [ canMap, dataCallbacks, realtime ], {
    updateMap: smartMerge
});

function smartMerge( instance, data ) { ... }
```