### PR TITLE
fixed wrong method name is docs for weak-reference-map Use section #240

### DIFF
--- a/helpers/weak-reference-map.js
+++ b/helpers/weak-reference-map.js
@@ -23,9 +23,9 @@ var assign = require("can-util/js/assign/assign");
  * wrm.has("1") //-> true
  * wrm.addReference("1", task1);
  * wrm.has("1") //-> true
- * wrm.removeReference("1", task1);
+ * wrm.deleteReference("1");
  * wrm.has("1") //-> true
- * wrm.removeReference("1", task1);
+ * wrm.deleteReference("1");
  * wrm.has("1") //-> false
  * ```
  */


### PR DESCRIPTION
Fixed method name in Use docs: `removeReference` changed to `deleteReference`

Issue: https://github.com/canjs/can-connect/issues/240