### PR TITLE
Issue/244/max call stack when no

### DIFF
--- a/can/constructor-hydrate/constructor-hydrate-test.js
+++ b/can/constructor-hydrate/constructor-hydrate-test.js
@@ -35,3 +35,22 @@ QUnit.test("basics", function(){
 	QUnit.equal(myPage.hub2, myPage.hub, 'Both properties refer to the same instance');
 	QUnit.equal(myPage.hub.name, 'OnePlus', 'The name of the 1st property should be changed since its the same instance now');
 });
+
+QUnit.test("Two objects with no id", function(){
+	var Hub = DefineMap.extend({});
+	Hub.List = DefineList.extend({
+		'#': { Type: Hub }
+	});
+	var HubConnection = connect([
+		constructorBehavior,
+		constructorStore,
+		mapBehavior,
+		hydrateBehavior,
+	], { Map: Hub, List: Hub.List });
+
+	var hub1 = new Hub({name: 'One'});
+	HubConnection.addInstanceReference(hub1);
+	QUnit.ok(!HubConnection.instanceStore.has(undefined), 'The instanceStore should not have an "undefined" key item');
+	var hub2 = new Hub({name: 'One'});
+	QUnit.ok(true, 'Should allow to create two instances without an id (no Max Call Stack error)');
+});

--- a/helpers/weak-reference-map.js
+++ b/helpers/weak-reference-map.js
@@ -64,6 +64,9 @@ assign(WeakReferenceMap.prototype,
 	 *   @param  {String} key The key of the item in the store.
 	 */
 	addReference: function(key, item){
+		if (typeof key === 'undefined'){
+			return;
+		}
 		var data = this.set[key];
 		if(!data) {
 			data = this.set[key] = {


### PR DESCRIPTION
Issue: https://github.com/canjs/can-connect/issues/244

If an item is created with no id and we `addReference` then `instanceStore` will have `undefined` key.

Then, if we create another item with the same `undefined` id, `can/constructor-hydrate/constructor-hydrate` will throw `Maximum call stack` error.

Solution: skip `undefined` key.