### PR TITLE
fixed can/ref to hydrate value if it has not been defined

### DIFF
--- a/can/ref/ref-test.js
+++ b/can/ref/ref-test.js
@@ -1,5 +1,4 @@
 var QUnit = require("steal-qunit");
-var sinon = require("sinon");
 var DefineMap = require("can-define/map/");
 var DefineList = require("can-define/list/");
 var constructorStore = require("can-connect/constructor/store/");
@@ -200,8 +199,10 @@ QUnit.asyncTest("populate Ref that was already created without a value", functio
 	var Team = DefineMap.extend({
 		id: "string"
 	});
+	var getDataCallCounter = 0;
 	Team.connection = connect([constructor, constructorStore, canMap, canRef, {
 		getData: function() {
+			getDataCallCounter++;
 			return Promise.resolve({ id: 3, name: "Bears" });
 		}
 	}],
@@ -225,15 +226,13 @@ QUnit.asyncTest("populate Ref that was already created without a value", functio
 
 	var handler = function(){};
 
-	sinon.spy(Team.connection, "getData");
-
 	Game.get({id: 1}).then(function(game){
 		game.on("teamRef", handler);
 		var teamRef = game.teamRef;
 
 		QUnit.ok( typeof teamRef.value === "undefined", "Value should be undefined");
-		QUnit.equal(teamRef.id, 3);
-		QUnit.equal(Team.connection.getData.callCount, 0, "Team getData should NOT be called");
+		QUnit.equal(teamRef.id, 3, "Id should be the correct one");
+		QUnit.equal(getDataCallCounter, 0, "Team getData should NOT be called");
 
 		Game.get({id: 1, populate: "teamRef"}).then(function(game){
 			// Now bind to teamRef:
@@ -241,8 +240,8 @@ QUnit.asyncTest("populate Ref that was already created without a value", functio
 
 			QUnit.ok( teamRef.value instanceof Team, "Value should be a Team");
 			QUnit.equal(teamRef.value.name, "Cubs", "Name should be Cubs");
-			QUnit.equal(teamRef.id, 3);
-			QUnit.equal(Team.connection.getData.callCount, 0, "Team getData should still NOT be called");
+			QUnit.equal(teamRef.id, 3, "Id should be the correct one");
+			QUnit.equal(getDataCallCounter, 0, "Team getData should still NOT be called");
 			QUnit.start();
 		});
 

--- a/can/ref/ref.js
+++ b/can/ref/ref.js
@@ -167,8 +167,12 @@ var makeRef = function(connection){
 			id = value[idProp];
 		}
 		// check if this is in the store
-		if(Ref.store.has(id)) {
-			return Ref.store.get(id);
+		var storeRef = Ref.store.get(id);
+		if(storeRef) {
+			if (value && !storeRef._value){
+				storeRef._value = connection.hydrateInstance(value);
+			}
+			return storeRef;
 		}
 		// if not, create it
 		this[idProp] = id;

--- a/can/ref/ref.js
+++ b/can/ref/ref.js
@@ -170,7 +170,11 @@ var makeRef = function(connection){
 		var storeRef = Ref.store.get(id);
 		if(storeRef) {
 			if (value && !storeRef._value){
-				storeRef._value = connection.hydrateInstance(value);
+				if(value instanceof connection.Map) {
+					storeRef._value = value;
+				} else {
+					storeRef._value = connection.hydrateInstance(value);
+				}
 			}
 			return storeRef;
 		}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "can-fixture": "^1.0.10",
     "jshint": "^2.9.4",
+    "sinon": "^1.17.7",
     "steal": "^1.0.1",
     "steal-css": "^1.0.0",
     "steal-qunit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "can-fixture": "^1.0.10",
     "jshint": "^2.9.4",
-    "sinon": "^1.17.7",
     "steal": "^1.0.1",
     "steal-css": "^1.0.0",
     "steal-qunit": "^1.0.0",


### PR DESCRIPTION
This fixes the bitcentive issue where unnecessary Ref getData calls are being called even when another request returned populated data.