### PR TITLE
callback-once: save last data with method name suffix

### DIFF
--- a/constructor/callbacks-once/callbacks-once.js
+++ b/constructor/callbacks-once/callbacks-once.js
@@ -58,13 +58,13 @@ module.exports = connect.behavior("constructor/callbacks-once",function(baseConn
 	forEach.call(callbacks, function(name){
 		behavior[name] = function(instance, data ){
 
-			var lastSerialized = this.getInstanceMetaData(instance, "last-data");
+			var lastSerialized = this.getInstanceMetaData(instance, "last-data-" + name);
 
 			var serialize = sortedSetJSON(data),
 				serialized = sortedSetJSON( this.serializeInstance( instance ) );
 			if(lastSerialized !== serialize) {
 				var result =  baseConnection[name].apply(this, arguments);
-				this.addInstanceMetaData(instance, "last-data", serialize);
+				this.addInstanceMetaData(instance, "last-data-" + name, serialize);
 				return result;
 			}
 		};

--- a/constructor/callbacks-once/callbacks-once.js
+++ b/constructor/callbacks-once/callbacks-once.js
@@ -60,8 +60,7 @@ module.exports = connect.behavior("constructor/callbacks-once",function(baseConn
 
 			var lastSerialized = this.getInstanceMetaData(instance, "last-data-" + name);
 
-			var serialize = sortedSetJSON(data),
-				serialized = sortedSetJSON( this.serializeInstance( instance ) );
+			var serialize = sortedSetJSON(data);
 			if(lastSerialized !== serialize) {
 				var result =  baseConnection[name].apply(this, arguments);
 				this.addInstanceMetaData(instance, "last-data-" + name, serialize);

--- a/constructor/callbacks-once/callbacks-once_test.js
+++ b/constructor/callbacks-once/callbacks-once_test.js
@@ -6,7 +6,6 @@ var constructorStore = require("can-connect/constructor/store/");
 var canMap = require("can-connect/can/map/");
 var dataCallbacks = require("can-connect/data/callbacks/");
 var callbacksOnce = require("can-connect/constructor/callbacks-once/");
-var dataUrl = require("can-connect/data/url/url");
 var DefineMap = require('can-define/map/');
 require('can-define/list/list');
 
@@ -42,58 +41,48 @@ QUnit.test('createInstance triggers a "created" event', function(assert){
 	});
 });
 
-QUnit.test("different methods should not refer to the same item", function(assert){
-	var done = assert.async();
-
+QUnit.test("different methods should not refer to the same last item", function(){
 	var Session = DefineMap.extend({
+		id: 'number',
 		email: 'string'
 	});
+	var createdCalled = 0;
+	var destroyedCalled = 0;
+
 	Session.connection = connect([
-		constructor,
-		canMap,
 		constructorStore,
-		dataCallbacks,
-		realTime,
-		callbacksOnce,
-		function(baseConnection){
-			return {
-				createdInstance: function(instance, props){
-					// Keep instance in instanceStore:
-					this.addInstanceReference(instance);
-					baseConnection.createdInstance.apply(this, arguments);
-				},
-				// simulate a connection like dataUrl:
-				destroyData: function(data){
-					return Promise.resolve(data);
-				}
+		{
+			// simulate can/map/map's `id`:
+			id: function(instance){
+				return instance.id;
+			},
+			// simulate can/constructor/constructor:
+			createdInstance: function(instance, data){
+				this.addInstanceReference(instance);
+				createdCalled++;
+			},
+			// simulate can/constructor/constructor:
+			destroyedInstance: function(instance, data){
+				destroyedCalled++;
 			}
-		}
+		},
+		callbacksOnce
 	], {
 		Map: Session
 	});
 
-	var createdCalled = 0;
-	Session.on("created", function(){
-		createdCalled++;
-	});
-
-	var destroyedCalled = 0;
-	Session.on("destroyed", function(){
-		destroyedCalled++;
-	});
-
-	Session.connection.createInstance({
+	var data = {
 		id: 100,
 		email: 'ilya@bitovi.com'
-	}).then(function(instance){
-		QUnit.equal(createdCalled, 1, "created event should be called");
-		return instance.destroy().then(function(){
-			QUnit.equal(destroyedCalled, 1, "destroyed event should be called");
-			Session.connection;
-			done();
-		}).catch(function(err){
-			QUnit.ok(false, 'should not be any errors');
-			done();
-		});
-	});
+	};
+
+	var instance = new Session(data);
+
+	Session.connection.createdInstance(instance, data);
+	Session.connection.createdInstance(instance, data);
+	Session.connection.destroyedInstance(instance, data);
+	Session.connection.destroyedInstance(instance, data);
+
+	QUnit.equal(createdCalled, 1, "created event should be called once");
+	QUnit.equal(destroyedCalled, 1, "destroyed event should be called once");
 });

--- a/constructor/callbacks-once/callbacks-once_test.js
+++ b/constructor/callbacks-once/callbacks-once_test.js
@@ -6,7 +6,9 @@ var constructorStore = require("can-connect/constructor/store/");
 var canMap = require("can-connect/can/map/");
 var dataCallbacks = require("can-connect/data/callbacks/");
 var callbacksOnce = require("can-connect/constructor/callbacks-once/");
+var dataUrl = require("can-connect/data/url/url");
 var DefineMap = require('can-define/map/');
+require('can-define/list/list');
 
 QUnit.module("can-connect/callbacks-once");
 
@@ -37,5 +39,61 @@ QUnit.test('createInstance triggers a "created" event', function(assert){
 	connection.createInstance({
 		id: 5,
 		email: 'marshall@bitovi.com'
+	});
+});
+
+QUnit.test("different methods should not refer to the same item", function(assert){
+	var done = assert.async();
+
+	var Session = DefineMap.extend({
+		email: 'string'
+	});
+	Session.connection = connect([
+		constructor,
+		canMap,
+		constructorStore,
+		dataCallbacks,
+		realTime,
+		callbacksOnce,
+		function(baseConnection){
+			return {
+				createdInstance: function(instance, props){
+					// Keep instance in instanceStore:
+					this.addInstanceReference(instance);
+					baseConnection.createdInstance.apply(this, arguments);
+				},
+				// simulate a connection like dataUrl:
+				destroyData: function(data){
+					return Promise.resolve(data);
+				}
+			}
+		}
+	], {
+		Map: Session
+	});
+
+	var createdCalled = 0;
+	Session.on("created", function(){
+		createdCalled++;
+	});
+
+	var destroyedCalled = 0;
+	Session.on("destroyed", function(){
+		destroyedCalled++;
+	});
+
+	Session.connection.createInstance({
+		id: 100,
+		email: 'ilya@bitovi.com'
+	}).then(function(instance){
+		QUnit.equal(createdCalled, 1, "created event should be called");
+		return instance.destroy().then(function(){
+			QUnit.equal(destroyedCalled, 1, "destroyed event should be called");
+			Session.connection;
+			done();
+		}).catch(function(err){
+			QUnit.ok(false, 'should not be any errors');
+			done();
+		});
 	});
 });

--- a/constructor/callbacks-once/callbacks-once_test.js
+++ b/constructor/callbacks-once/callbacks-once_test.js
@@ -42,10 +42,10 @@ QUnit.test('createInstance triggers a "created" event', function(assert){
 });
 
 QUnit.test("different methods should not refer to the same last item", function(){
-	var Session = DefineMap.extend({
-		id: 'number',
-		email: 'string'
-	});
+	function Session(data){
+		this.id = data.id;
+		this.email = data.email;
+	}
 	var createdCalled = 0;
 	var destroyedCalled = 0;
 

--- a/constructor/callbacks-once/test.html
+++ b/constructor/callbacks-once/test.html
@@ -1,0 +1,3 @@
+<title>can-connect tests</title>
+<script src="../../node_modules/steal/steal.js" main="can-connect/constructor/callbacks-once/callbacks-once_test"></script>
+<div id="qunit-fixture"></div>


### PR DESCRIPTION
This is to  to distinguish between method calls. E.g.:

when `createdData` callback-once is called it remembers that the callback was called with some data (to avoid double calls of the same, e.g. one is ajax another could be with websocket), so that this wont affect `destroyedData` callback.