### PR TITLE
Smart merge id prop

### DIFF
--- a/helpers/map-deep-merge-test.js
+++ b/helpers/map-deep-merge-test.js
@@ -15,6 +15,7 @@ var applyPatch = require('./map-deep-merge').applyPatch;
 var applyPatchPure = smartMerge.applyPatchPure;
 var mergeInstance = smartMerge.mergeInstance;
 var mergeList = smartMerge.mergeList;
+var idFromType = smartMerge.idFromType;
 
 var QUnit = require('steal-qunit');
 QUnit.noop = function(){};
@@ -270,6 +271,43 @@ QUnit.test("Merging non-defined, but object, types", function(){
 	mergeInstance(map, {a: last});
 
 	QUnit.equal(map.a, last);
+});
+
+QUnit.test("idFromType", function(assert){
+	var Car = DefineMap.extend({
+		vin: {type: 'string'},
+		color: {type: 'string'}
+	});
+	Car.algebra = new set.Algebra( set.props.id('vin') );
+	var id = idFromType(Car);
+	var myCar = new Car({vin: "1", color: "black"});
+
+	assert.equal(id(myCar), "1", "id is retrieved from algebra with a custom id prop");
+});
+
+QUnit.test("custom id prop", function(assert){
+
+	var Car = DefineMap.extend({
+		vin: {type: 'string'},
+		color: {type: 'string'}
+	});
+	Car.algebra = new set.Algebra( set.props.id('vin') );
+	Car.List = DefineList.extend({ '#' : Car });
+
+	var items = new Car.List([
+		{ vin: '1', color: 'black' },
+		{ vin: '2', color: 'blue' },
+	]);
+	var data = [
+		{ vin: '2', color: 'blue' },
+		{ vin: '1', color: 'red' },
+	];
+
+	assert.deepEqual(items[0].serialize(), { vin: '1', color: 'black' }, "The 1st item is what we want it to be");
+
+	smartMerge(items, data);
+
+	assert.deepEqual(items[0].serialize(), { vin: '1', color: 'red' }, "The 1st item was updated correctly");
 });
 
 /*

--- a/helpers/map-deep-merge-test.js
+++ b/helpers/map-deep-merge-test.js
@@ -285,29 +285,34 @@ QUnit.test("idFromType", function(assert){
 	assert.equal(id(myCar), "1", "id is retrieved from algebra with a custom id prop");
 });
 
-QUnit.test("custom id prop", function(assert){
+QUnit.test("custom id prop for instance store", function(assert){
 
 	var Car = DefineMap.extend({
-		vin: {type: 'string'},
-		color: {type: 'string'}
+		vin: {type: "string"},
+		color: {type: "string"}
 	});
-	Car.algebra = new set.Algebra( set.props.id('vin') );
-	Car.List = DefineList.extend({ '#' : Car });
+	Car.algebra = new set.Algebra( set.props.id("vin") );
+	Car.List = DefineList.extend({ "#" : Car });
 
+	var id = idFromType(Car);
 	var items = new Car.List([
-		{ vin: '1', color: 'black' },
-		{ vin: '2', color: 'blue' },
+		{ vin: "1", color: "black" },
+		{ vin: "2", color: "blue" },
 	]);
+	var toStore = function(map, item){ map[item.vin] = item; return map;};
+	var instanceStore = [].reduce.call(items, toStore, {});
 	var data = [
-		{ vin: '2', color: 'blue' },
-		{ vin: '1', color: 'red' },
+		{ vin: "2", color: "blue" },
+		{ vin: "1", color: "red" },
 	];
 
-	assert.deepEqual(items[0].serialize(), { vin: '1', color: 'black' }, "The 1st item is what we want it to be");
+	assert.ok(items[0].vin === "1", "The 1st item is with id 1");
+	assert.deepEqual(instanceStore["1"].serialize(), { vin: "1", color: "black" }, "The item with id=1 is what we want it to be");
 
 	smartMerge(items, data);
 
-	assert.deepEqual(items[0].serialize(), { vin: '1', color: 'red' }, "The 1st item was updated correctly");
+	assert.deepEqual(instanceStore["1"].serialize(), { vin: "1", color: "red" }, "The item with id=1 was updated correctly");
+	assert.ok(items[0].vin === "2", "items were swapped in the list which is what we expected");
 });
 
 /*

--- a/helpers/map-deep-merge.js
+++ b/helpers/map-deep-merge.js
@@ -205,3 +205,4 @@ smartMerge.mergeInstance = mergeInstance;
 smartMerge.mergeList = mergeList;
 smartMerge.applyPatch = applyPatch;
 smartMerge.applyPatchPure = applyPatchPure;
+smartMerge.idFromType = idFromType;

--- a/helpers/map-deep-merge.js
+++ b/helpers/map-deep-merge.js
@@ -173,7 +173,8 @@ function typeFromList( list ){
 }
 function idFromType( Type ){
 	return Type && Type.algebra && Type.algebra.clauses && Type.algebra.clauses.id && function(o){
-			return o[Type.algebra.clauses.id.id];
+			var idProp = Object.keys(Type.algebra.clauses.id)[0];
+			return o[idProp];
 		} || function(o){
 			return o.id || o._id;
 		};

--- a/helpers/map-deep-merge.js
+++ b/helpers/map-deep-merge.js
@@ -172,7 +172,8 @@ function typeFromList( list ){
 	return list && list._define && list._define.definitions["#"] && list._define.definitions["#"].Type;
 }
 function idFromType( Type ){
-	return Type && Type.algebra && Type.algebra.clauses && Type.algebra.clauses.id && function(o){
+	return Type && Type.connection && Type.connection.id ||
+		Type && Type.algebra && Type.algebra.clauses && Type.algebra.clauses.id && function(o){
 			var idProp = Object.keys(Type.algebra.clauses.id)[0];
 			return o[idProp];
 		} || function(o){


### PR DESCRIPTION
idFromType was incorrectly retrieving id from algebra.

With that bug `map-deep-merge` is almost replacing the items with the updated data. "Almost" because the item with `id=1, _cid=1` could be merged with data for `id=2`. So items `_cid=1` and `_cid=2` would be "swapped" regarding to data. This can mess up `instanceStore`.