### PR TITLE
Adapt map and model behavior to use new can-event lifecycle structure

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -523,7 +523,7 @@ var mapOverwrites = {	// ## can.Model#bind and can.Model#unbind
 	___set: function (base, connection) {
 		return function(prop, val){
 			base.apply(this, arguments);
-			if ( prop === connection.idProp && this._bindings ) {
+			if ( prop === connection.idProp && this.__bindEvents && this.__bindEvents._lifecycleBindings ) {
 				connection.addInstanceReference(this);
 			}
 		};

--- a/can/model/model.js
+++ b/can/model/model.js
@@ -306,7 +306,7 @@ var CanModel = CanMap.extend({
 		CanMap.prototype.___set.call(this, prop, val);
 		// If we add or change the ID, update the store accordingly.
 		// TODO: shouldn't this also delete the record from the old ID in the store?
-		if ( prop === (this.constructor.id || "id") && this._bindings ) {
+		if ( prop === (this.constructor.id || "id") && this.__bindEvents && this.__bindEvents._lifecycleBindings ) {
 			this.constructor.connection.addInstanceReference(this);
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "can-compute": "^3.0.4",
     "can-construct": "^3.1.0",
     "can-define": "^1.0.9",
-    "can-event": "^3.0.1",
+    "can-event": "^3.3.0",
     "can-list": "^3.0.1",
     "can-map": "^3.0.3",
     "can-namespace": "1.0.0",


### PR DESCRIPTION
That just means that the property for the count of lifecycle bindings is now `.__bindEvents._lifecycleBindings` instead of `._bindings`
