### PR TITLE
#270 Replace call to `JSON.stringify()` …

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "can-stache": "^3.0.13",
     "can-stache-bindings": "^3.0.5",
     "can-types": "^1.0.0",
-    "can-util": "^3.2.2",
+    "can-util": "^3.7.0",
     "can-view-callbacks": "^3.0.2",
     "can-view-nodelist": "^3.0.2",
     "jquery": "2.x - 3.x",

--- a/real-time/real-time.js
+++ b/real-time/real-time.js
@@ -351,11 +351,11 @@ module.exports = connect.behavior("real-time",function(baseConnection){
 					item = items.data[i];
 					if( !self.algebra.has(set, item) ) {
 						var msg = "One or more items were retrieved which do not match the 'Set' parameters used to load them. "
-							+ "Read the docs for more information: http://v3.canjs.com/doc/can-set.html#SolvingCommonIssues"
+							+ "Read the docs for more information: https://canjs.com/doc/can-set.html#SolvingCommonIssues"
 							+ "\n\nBelow are the 'Set' parameters:"
-							+ "\n" + JSON.stringify(set, null, "  ")
+							+ "\n" + canDev.stringify(set)
 							+ "\n\nAnd below is an item which does not match those parameters:"
-							+ "\n" + JSON.stringify(item, null, "  ");
+							+ "\n" + canDev.stringify(item);
 						canDev.warn(msg);
 						break;
 					}


### PR DESCRIPTION
… with `can-util/js/dev/dev.stringify` so that properties with a value of `undefined` show up in dev warnings. (e.g. `canDev.stringify({ foo: undefined }) // "{ "foo": undefined }"`) Resolves #270

Currently, a set of `{ foo: undefined }` is being incorrectly logged as `{}` by a warning message in the real-time behavior.