### PR TITLE
Remove jQuery as a dep (leave as devDependency for tests)

### DIFF
--- a/can/base-map/base-map.js
+++ b/can/base-map/base-map.js
@@ -10,9 +10,10 @@ var dataParse = require("../../data/parse/parse");
 var dataUrl = require("../../data/url/url");
 var realTime = require("../../real-time/real-time");
 var callbacksOnce = require("../../constructor/callbacks-once/callbacks-once");
+var GLOBAL = require("can-util/js/global/global");
 
 
-var $ = require("jquery");
+var $ = GLOBAL().$;
 
 connect.baseMap = function(options){
 

--- a/can/base-map/base-map_test.js
+++ b/can/base-map/base-map_test.js
@@ -2,6 +2,8 @@ var QUnit = require("steal-qunit");
 var fixture = require("can-fixture");
 var Map = require("can-map");
 var baseMap = require("can-connect/can/base-map/");
+var GLOBAL = require("can-util/js/global/global");
+var stealClone = require("steal-clone");
 
 QUnit.module("can-connect/can/base-map");
 
@@ -54,4 +56,31 @@ QUnit.test("creates map if none is provided (#8)", function(){
 	});
 
 
+});
+
+QUnit.test("uses jQuery if loaded", 2, function() {
+	stop();
+	var old$ = GLOBAL().$;
+	var fake$ = {
+		ajax: function() {}
+	};
+	GLOBAL().$ = fake$;
+	stealClone({}).import("can-connect/can/base-map/base-map").then(function(baseMap) {
+		var connection = baseMap({
+			Map: function() {},
+			List: function() {}
+		});
+		QUnit.equal(connection.ajax, fake$.ajax, "ajax is set from existing $");
+	}).then(function() {
+		GLOBAL().$ = undefined;
+		return stealClone({}).import("can-connect/can/base-map/base-map");
+	}).then(function(baseMap) {
+		var connection = baseMap({
+			Map: function() {},
+			List: function() {}
+		});
+		QUnit.equal(connection.ajax, undefined, "ajax is not set when no $");
+		GLOBAL().$ = old$;
+		start();
+	});
 });

--- a/can/super-map/super-map.js
+++ b/can/super-map/super-map.js
@@ -13,9 +13,9 @@ var dataUrl = require("../../data/url/url");
 var fallThroughCache = require("../../fall-through-cache/fall-through-cache");
 var realTime = require("../../real-time/real-time");
 var callbacksOnce = require("../../constructor/callbacks-once/callbacks-once");
+var GLOBAL = require("can-util/js/global/global");
 
-
-var $ = require("jquery");
+var $ = GLOBAL().$;
 
 connect.superMap = function(options){
 

--- a/can/super-map/super-map_test.js
+++ b/can/super-map/super-map_test.js
@@ -3,6 +3,8 @@ var fixture = require("can-fixture");
 var Map = require("can-map");
 var superMap = require("can-connect/can/super-map/");
 var set = require("can-set");
+var GLOBAL = require("can-util/js/global/global");
+var stealClone = require("steal-clone");
 
 QUnit.module("can-connect/can/super-map");
 
@@ -112,3 +114,31 @@ QUnit.test("uses idProp from algebra (#255)", function(){
 
 
 });
+
+QUnit.test("uses jQuery if loaded", 2, function() {
+	stop();
+	var old$ = GLOBAL().$;
+	var fake$ = {
+		ajax: function() {}
+	};
+	GLOBAL().$ = fake$;
+	stealClone({}).import("can-connect/can/super-map/super-map").then(function(superMap) {
+		var connection = superMap({
+			Map: function() {},
+			List: function() {}
+		});
+		QUnit.equal(connection.ajax, fake$.ajax, "ajax is set from existing $");
+	}).then(function() {
+		GLOBAL().$ = undefined;
+		return stealClone({}).import("can-connect/can/super-map/super-map");
+	}).then(function(superMap) {
+		var connection = superMap({
+			Map: function() {},
+			List: function() {}
+		});
+		QUnit.equal(connection.ajax, undefined, "ajax is not set when no $");
+		GLOBAL().$ = old$;
+		start();
+	});
+});
+

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "can-util": "^3.7.0",
     "can-view-callbacks": "^3.0.2",
     "can-view-nodelist": "^3.0.2",
-    "jquery": "2.x - 3.x",
     "steal-stache": "^3.0.3"
   },
   "repository": {
@@ -29,6 +28,7 @@
   "devDependencies": {
     "can-fixture": "^1.0.10",
     "jshint": "^2.9.4",
+    "jquery": "2.x - 3.x",
     "steal": "^1.0.1",
     "steal-css": "^1.0.0",
     "steal-qunit": "^1.0.0",


### PR DESCRIPTION
BaseMap and SuperMap will set up jQuery.ajax as the ajax function used in the connection if jQuery is loaded, otherwise will leave it empty (and can.ajax will be used instead).

This removes any build or production time dependency on jQuery.  It's maintained as a dev dep for tests since some tests use it.

Addresses #292 