### PR TITLE
Fix validation errors

### DIFF
--- a/helpers/validate.js
+++ b/helpers/validate.js
@@ -29,16 +29,25 @@ function validateArgumentInterface(func, argIndex, interfaces, errorHandler) {
 	}
 }
 
+
 // change to 'BehaviourInterfaceError extends Error' once we drop support for pre-ES2015
 function BehaviorInterfaceError(baseBehavior, extendingBehavior, missingProps) {
 	var extendingName = extendingBehavior.behaviorName || 'anonymous behavior',
 		baseName = baseBehavior.__behaviorName || 'anonymous behavior',
 		message = 'can-connect: Extending behavior "' + extendingName + '" found base behavior "' + baseName
-			+ '" was missing required properties: ' + JSON.stringify(missingProps.related);
+			+ '" was missing required properties: ' + JSON.stringify(missingProps.related),
+		instance = new Error(message);
 
-	this.name = 'BehaviorInterfaceError';
-	this.message = message;
-	this.stack = (new Error()).stack;
+	if (Object.setPrototypeOf){
+		Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+	}
+	return instance;
 }
-BehaviorInterfaceError.prototype = Object.create(Error.prototype);
-BehaviorInterfaceError.prototype.constructor = BehaviorInterfaceError;
+BehaviorInterfaceError.prototype = Object.create(Error.prototype, {
+	constructor: {value: Error}
+});
+if (Object.setPrototypeOf){
+	Object.setPrototypeOf(BehaviorInterfaceError, Error);
+} else {
+	BehaviorInterfaceError.__proto__ = Error;
+}


### PR DESCRIPTION
Make BehaviorInterfaceError print a nicely formatted error in the console while also asserting:
```
((new BehaviorInterfaceError({},{},['test'])) instanceof Error) === true
((new BehaviorInterfaceError({},{},['test'])) instanceof BehaviorInterfaceError) === true
```
The second assertion above doesn't pass in IE9 but otherwise the error still works as expected: printing a nice log w/ stack trace, etc.

This implementation is based on the most recent answer in [this StackOverflow thread](https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript) that is referenced on the [MDN for Custom Errors](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types).
