### PR TITLE
make setting `url` resource consistent with can-fixture's urls

### DIFF
--- a/can/base-map/base-map_test.js
+++ b/can/base-map/base-map_test.js
@@ -68,7 +68,8 @@ QUnit.test("uses jQuery if loaded", 2, function() {
 	stealClone({}).import("can-connect/can/base-map/base-map").then(function(baseMap) {
 		var connection = baseMap({
 			Map: function() {},
-			List: function() {}
+			List: function() {},
+			url: "/fake"
 		});
 		QUnit.equal(connection.ajax, fake$.ajax, "ajax is set from existing $");
 	}).then(function() {
@@ -77,7 +78,8 @@ QUnit.test("uses jQuery if loaded", 2, function() {
 	}).then(function(baseMap) {
 		var connection = baseMap({
 			Map: function() {},
-			List: function() {}
+			List: function() {},
+			url: "/fake"
 		});
 		QUnit.equal(connection.ajax, undefined, "ajax is not set when no $");
 		GLOBAL().$ = old$;

--- a/can/super-map/super-map_test.js
+++ b/can/super-map/super-map_test.js
@@ -131,7 +131,8 @@ QUnit.test("uses jQuery if loaded", 2, function() {
 	stealClone({}).import("can-connect/can/super-map/super-map").then(function(superMap) {
 		var connection = superMap({
 			Map: function() {},
-			List: function() {}
+			List: function() {},
+			url: "/fake"
 		});
 		QUnit.equal(connection.ajax, fake$.ajax, "ajax is set from existing $");
 	}).then(function() {
@@ -140,11 +141,11 @@ QUnit.test("uses jQuery if loaded", 2, function() {
 	}).then(function(superMap) {
 		var connection = superMap({
 			Map: function() {},
-			List: function() {}
+			List: function() {},
+			url: "/fake"
 		});
 		QUnit.equal(connection.ajax, undefined, "ajax is not set when no $");
 		GLOBAL().$ = old$;
 		start();
 	});
 });
-

--- a/data/url/data-url_test.js
+++ b/data/url/data-url_test.js
@@ -2,6 +2,7 @@ var QUnit = require("steal-qunit");
 var fixture = require("can-fixture");
 var persist = require("can-connect/data/url/");
 var $ = require("jquery");
+var set = require("can-set");
 
 QUnit.module("can-connect/data/url",{
 	setup: function(){
@@ -241,5 +242,53 @@ QUnit.test("getting a real Promise back with objects using makeAjax setting this
 
 	ok(connection.getData({foo: "bar", id: 2}).catch, 'getData Promise has a catch method');
 	ok(!connection.getData({foo: "bar", id: 2}).fail, 'getData Promise does not have a fail method');
+
+});
+
+QUnit.asyncTest("fixture stores work with data (#298)", function(){
+
+	var todoStore = fixture.store([{
+		id: "1",
+		name: "todo 1"
+	}]);
+
+	fixture("/v1/places/todos/{id}", todoStore);
+
+	var connection = persist({
+		url: "/v1/places/todos/{id}"
+	});
+
+	connection.getData({id: 1}).then(function(todo){
+		QUnit.equal(todo.name, "todo 1");
+	}).then(function(){
+
+		var algebra = new set.Algebra(
+			set.props.id("_todoId")
+		);
+
+		var todoStore = fixture.store([{
+			_todoId: "1",
+			name: "todo 1"
+		}], algebra);
+
+		fixture("/v2/places/todos", todoStore);
+
+		var connection = persist({
+			url: "/v2/places/todos",
+			algebra: algebra
+		});
+
+		connection.getData({_todoId: "1"}).then(function(todo){
+			QUnit.equal(todo.name, "todo 1");
+			QUnit.start();
+		});
+
+
+	});
+
+
+
+
+
 
 });

--- a/data/url/url.js
+++ b/data/url/url.js
@@ -102,6 +102,9 @@ var string = require("can-util/js/string/string");
 var getIdProps = require("../../helpers/get-id-props");
 var dev = require("can-util/js/dev/dev");
 var connect = require("can-connect");
+var makeRest = require("can-make-rest");
+
+var defaultRest = makeRest("/resource/{id}");
 
 var makePromise = require("can-util/js/make-promise/make-promise");
 
@@ -109,31 +112,38 @@ var makePromise = require("can-util/js/make-promise/make-promise");
 // For each pair, create a function that checks the url object
 // and creates an ajax request.
 var urlBehavior = connect.behavior("data/url", function(baseConnection) {
-
-
 	var behavior = {};
-	each(pairs, function(reqOptions, name) {
-		behavior[name] = function(params) {
+	each(defaultRest, function(defaultData, dataInterfaceName){
+		behavior[dataInterfaceName] = function(params) {
+			var meta = methodMetaData[dataInterfaceName];
 
 			if(typeof this.url === "object") {
-				if(typeof this.url[reqOptions.prop] === "function") {
+				if(typeof this.url[dataInterfaceName] === "function") {
 
-					return makePromise(this.url[reqOptions.prop](params));
+					return makePromise(this.url[dataInterfaceName](params));
 				}
-				else if(this.url[reqOptions.prop]) {
-					return makePromise(makeAjax(this.url[reqOptions.prop], params, reqOptions.type, this.ajax || ajax, findContentType(this.url), reqOptions));
+				else if(this.url[dataInterfaceName]) {
+					var promise = makeAjax(
+							this.url[dataInterfaceName],
+							params,
+							defaultData.method,
+							this.ajax || ajax,
+							findContentType(this.url),
+							meta);
+					return makePromise(promise);
 				}
 			}
 
 			var resource = typeof this.url === "string" ? this.url : this.url.resource;
 			if( resource ) {
 				var idProps = getIdProps(this);
-				return makePromise(makeAjax( createURLFromResource(resource, idProps[0] ,
-					reqOptions.prop ),
-					params, reqOptions.type,
+				var resourceWithoutTrailingSlashes = resource.replace(/\/+$/, "");
+				var result = makeRest(resourceWithoutTrailingSlashes, idProps[0])[dataInterfaceName];
+				return makePromise(makeAjax( result.url,
+					params, result.method,
 					this.ajax || ajax,
 					findContentType(this.url),
-					reqOptions));
+					meta));
 			}
 
 			return baseConnection[name].call(this, params);
@@ -225,11 +235,9 @@ var urlBehavior = connect.behavior("data/url", function(baseConnection) {
   *   @return {Promise} A Promise that resolves to the data.
   */
 
-// ## pairs
-// The functions that will be created mapped to an object with:
-// - prop - the property to look for in connection.url for a url
-// - type - the default http method if one is not provided in the url
-var pairs = {
+// ## methodMetaData
+// Metadata on different methods that is passed to makeAjax
+var methodMetaData = {
 	/**
 	 * @function can-connect/data/url/url.getListData getListData
 	 * @parent can-connect/data/url/url.data-methods
@@ -244,7 +252,7 @@ var pairs = {
 	 *   @param {can-set/Set} set A object that represents the set of data needed to be loaded.
 	 *   @return {Promise<can-connect.listData>} A promise that resolves to the ListData format.
 	 */
-	getListData: {prop: "getListData", type: "GET"},
+	getListData: {},
 	/**
 	 * @function can-connect/data/url/url.getData getData
 	 * @parent can-connect/data/url/url.data-methods
@@ -259,7 +267,7 @@ var pairs = {
 	 *   @param {Object} params A object that represents the set of data needed to be loaded.
 	 *   @return {Promise<Object>} A promise that resolves to the instance data.
 	 */
-	getData: {prop: "getData", type: "GET"},
+	getData: {},
 	/**
 	 * @function can-connect/data/url/url.createData createData
 	 * @parent can-connect/data/url/url.data-methods
@@ -276,7 +284,7 @@ var pairs = {
 	 *   @param {Number} cid A unique id that represents the instance that is being created.
 	 *   @return {Promise<Object>} A promise that resolves to the newly created instance data.
 	 */
-	createData: {prop: "createData", type: "POST"},
+	createData: {},
 	/**
 	 * @function can-connect/data/url/url.updateData updateData
 	 * @parent can-connect/data/url/url.data-methods
@@ -292,7 +300,7 @@ var pairs = {
 	 *   @param {Object} instanceData The serialized data of the instance.
 	 *   @return {Promise<Object>} A promise that resolves to the updated instance data.
 	 */
-	updateData: {prop: "updateData", type: "PUT"},
+	updateData: {},
 	/**
 	 * @function can-connect/data/url/url.destroyData destroyData
 	 * @parent can-connect/data/url/url.data-methods
@@ -308,7 +316,7 @@ var pairs = {
 	 *   @param {Object} instanceData The serialized data of the instance.
 	 *   @return {Promise<Object>} A promise that resolves to the deleted instance data.
 	 */
-	destroyData: {prop: "destroyData", type: "DELETE", includeData: false}
+	destroyData: {includeData: false}
 };
 
 var findContentType = function( url ) {
@@ -367,16 +375,6 @@ var makeAjax = function ( ajaxOb, data, type, ajax, contentType, reqOptions ) {
 		type: type || 'post',
 		dataType: 'json'
 	}, params));
-};
-
-var createURLFromResource = function(resource, idProp, name) {
-
-	var url = resource.replace(/\/+$/, "");
-	if (name === "getListData" || name === "createData") {
-		return url;
-	} else {
-		return url + "/{" + idProp + "}";
-	}
 };
 
 module.exports = urlBehavior;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "can-define": "^1.0.9",
     "can-event": "^3.3.0",
     "can-list": "^3.0.1",
+    "can-make-rest": "0.0.2",
     "can-map": "^3.0.3",
     "can-namespace": "1.0.0",
     "can-observation": "^3.0.3",


### PR DESCRIPTION
fixes #298 by making the following work:

```js
	var todoStore = fixture.store([{
		id: "1",
		name: "todo 1"
	}]);

	fixture("/v1/places/todos/{id}", todoStore);

	var connection = persist({
		url: "/v1/places/todos/{id}"
	});

	connection.getData({id: 1}).then(function(todo){
		QUnit.equal(todo.name, "todo 1");
	})
```

I did this by creating a `can-make-rest` package.  `can-make-rest` is 0.0.2.  We won't document it now.  I hard-coded the release can-connect points to so this all should be fine to make a patch release.