### PR TITLE
data/url: Always provide contentType

### DIFF
--- a/data/url/data-url_test.js
+++ b/data/url/data-url_test.js
@@ -154,6 +154,26 @@ QUnit.test("contentType can be form-urlencoded (#134)", function() {
 	});
 });
 
+QUnit.test("contentType defaults to form-urlencoded for GET", function() {
+	var connection = persist({
+		url: {
+			getData: "GET /api/restaurants"
+		}
+	});
+
+	fixture({
+		"GET /api/restaurants": function(request){
+			equal(request.headers["Content-Type"], "application/x-www-form-urlencoded");
+			return request.data;
+		}
+	});
+
+	stop();
+	connection.getData({foo:"bar"}).then(function() {
+		start();
+	});
+});
+
 QUnit.test("getting a real Promise back with functions", function() {
 	var connection = persist({
 		url: {

--- a/data/url/url.js
+++ b/data/url/url.js
@@ -128,7 +128,7 @@ var urlBehavior = connect.behavior("data/url", function(baseConnection) {
 							params,
 							defaultData.method,
 							this.ajax || ajax,
-							findContentType(this.url),
+							findContentType(this.url, defaultData.method),
 							meta);
 					return makePromise(promise);
 				}
@@ -142,7 +142,7 @@ var urlBehavior = connect.behavior("data/url", function(baseConnection) {
 				return makePromise(makeAjax( result.url,
 					params, result.method,
 					this.ajax || ajax,
-					findContentType(this.url),
+					findContentType(this.url, result.method),
 					meta));
 			}
 
@@ -319,7 +319,7 @@ var methodMetaData = {
 	destroyData: {includeData: false}
 };
 
-var findContentType = function( url ) {
+var findContentType = function( url, method ) {
 	if ( typeof url === 'object' && url.contentType ) {
 		var acceptableType = url.contentType === 'application/x-www-form-urlencoded' ||
 			url.contentType === 'application/json';
@@ -332,7 +332,7 @@ var findContentType = function( url ) {
 			//!steal-remove-end
 		}
 	}
-	return 'application/json';
+	return method === "GET" ? "application/x-www-form-urlencoded" : "application/json";
 };
 
 var makeAjax = function ( ajaxOb, data, type, ajax, contentType, reqOptions ) {
@@ -358,14 +358,7 @@ var makeAjax = function ( ajaxOb, data, type, ajax, contentType, reqOptions ) {
 
 	// Substitute in data for any templated parts of the URL.
 	params.url = string.sub(params.url, params.data, true);
-
-	// Default to JSON encoding, if contentType is not form-urlencoded
-	var encodeJSON = contentType !== 'application/x-www-form-urlencoded' &&
-		(type && (type === 'POST' || type === 'PUT'));
-	if (encodeJSON) {
-		params.data = JSON.stringify(params.data);
-		params.contentType = contentType;
-	}
+	params.contentType = contentType;
 
 	if(reqOptions.includeData === false) {
 		delete params.data;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "can-stache": "^3.0.13",
     "can-stache-bindings": "^3.0.5",
     "can-types": "^1.0.0",
-    "can-util": "^3.7.0",
+    "can-util": "^3.8.5",
     "can-validate-interface": "0.1.0",
     "can-view-callbacks": "^3.0.2",
     "can-view-nodelist": "^3.0.2",


### PR DESCRIPTION
Always provide the contentType, but never serialize the data ourselves,
	   can-util/dom/ajax will do that.

Closes #305

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
