### PR TITLE
uses new can-reflect to not update typed data

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -327,16 +327,11 @@ var canMapBehavior = connect.behavior("can/map",function(baseConnection){
 
 			// Update attributes if attributes have been passed
 			if(props && typeof props === 'object') {
-				if("set" in instance) {
-					instance.set(isFunction(props.get) ? props.get() : props, this.constructor.removeAttr || false);
-				} else if("attr" in instance) {
-					instance.attr(isFunction(props.attr) ? props.attr() : props, this.constructor.removeAttr || false);
+
+				if(this.constructor.removeAttr) {
+					canReflect.updateDeep(instance, props);
 				} else {
-					canBatch.start();
-					each(props, function(value, prop){
-						instance[prop] = value;
-					});
-					canBatch.stop();
+					canReflect.assignDeep(instance, props);
 				}
 			}
 			// This happens in constructor/store, but we don't call base, so we have to do it ourselves.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "can-map": "^3.1.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0",
-    "can-reflect": "^1.0.0",
+    "can-reflect": "^1.2.0",
     "can-set": "^1.3.0",
     "can-stache": "^3.1.0",
     "can-stache-bindings": "^3.2.0",


### PR DESCRIPTION
this also changes `can/map` to use can-reflect's updateDeep