### PR TITLE
Replace deprecated can-util/js/is-array with Array.isArray

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -7,7 +7,6 @@ var canEvent = require("can-event");
 var Observation = require("can-observation");
 
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
-var isArray = require("can-util/js/is-array/is-array");
 var types = require("can-types");
 var each = require("can-util/js/each/each");
 var isFunction = require("can-util/js/is-function/is-function");
@@ -704,7 +703,7 @@ var listPrototypeOverwrites = {
 		return function (params) {
 			// If there was a plain object passed to the List constructor,
 			// we use those as parameters for an initial getList.
-			if (isPlainObject(params) && !isArray(params)) {
+			if (isPlainObject(params) && !Array.isArray(params)) {
 				this.__listSet = params;
 				base.apply(this);
 				this.replace(canReflect.isPromise(params) ? params : connection.getList(params));

--- a/constructor/constructor.js
+++ b/constructor/constructor.js
@@ -92,7 +92,6 @@
  *
  *
  */
-var isArray = require("can-util/js/is-array/is-array");
 var makeArray = require("can-util/js/make-array/make-array");
 var assign = require("can-util/js/assign/assign");
 var connect = require("can-connect");
@@ -211,7 +210,7 @@ module.exports = connect.behavior("constructor",function(baseConnection){
 		 *   @return {can-connect.List} The data type used to represent the list.
 		 */
 		hydrateList: function(listData, set){
-			if(isArray(listData)) {
+			if(Array.isArray(listData)) {
 				listData = {data: listData};
 			}
 
@@ -352,7 +351,7 @@ module.exports = connect.behavior("constructor",function(baseConnection){
 				// It should be given a local id and temporarily added to the cidStore
 				// so other hooks can get back the instance that's being created.
 				var cid = this._cid++;
-				// cid is really a token to be able to reference this transaction. 
+				// cid is really a token to be able to reference this transaction.
 				this.cidStore.addReference(cid, instance);
 
 				// Call the data layer.

--- a/data/parse/parse.js
+++ b/data/parse/parse.js
@@ -55,7 +55,6 @@
  */
  var connect = require("can-connect");
  var each = require("can-util/js/each/each");
- var isArray = require("can-util/js/is-array/is-array");
  var getObject = require("can-util/js/get/get");
 
 
@@ -137,7 +136,7 @@ module.exports = connect.behavior("data/parse",function(baseConnection){
 			}
 
 			var result;
-			if( isArray(responseData) ) {
+			if( Array.isArray(responseData) ) {
 				result = {data: responseData};
 			} else {
 				var prop = this.parseListProp || 'data';
@@ -147,7 +146,7 @@ module.exports = connect.behavior("data/parse",function(baseConnection){
 				if(prop !== "data") {
 					delete responseData[prop];
 				}
-				if(!isArray(result.data)) {
+				if(!Array.isArray(result.data)) {
 					throw new Error('Could not get any raw data while converting using .parseListData');
 				}
 

--- a/data/url/url.js
+++ b/data/url/url.js
@@ -94,7 +94,6 @@
  *
  * This does the same thing as the first `todoConnection` example.
  */
-var isArray = require("can-util/js/is-array/is-array");
 var assign = require("can-util/js/assign/assign");
 var each = require("can-util/js/each/each");
 var ajax = require("can-util/dom/ajax/ajax");
@@ -353,7 +352,7 @@ var makeAjax = function ( ajaxOb, data, type, ajax, contentType, reqOptions ) {
 	}
 
 	// If the `data` argument is a plain object, copy it into `params`.
-	params.data = typeof data === "object" && !isArray(data) ?
+	params.data = typeof data === "object" && !Array.isArray(data) ?
 		assign(params.data || {}, data) : data;
 
 	// Substitute in data for any templated parts of the URL.

--- a/helpers/clone-data.js
+++ b/helpers/clone-data.js
@@ -1,6 +1,5 @@
-var isArray = require("can-util/js/is-array/is-array");
 var deepAssign = require("can-util/js/deep-assign/deep-assign");
 
 module.exports = function(data) {
-	return isArray(data) ? data.slice(0) : deepAssign({}, data);
+	return Array.isArray(data) ? data.slice(0) : deepAssign({}, data);
 };

--- a/helpers/get-items.js
+++ b/helpers/get-items.js
@@ -1,7 +1,5 @@
-var isArray = require("can-util/js/is-array/is-array");
-
 module.exports = function(data){
-	if(isArray(data)) {
+	if(Array.isArray(data)) {
 		return data;
 	} else {
 		return data.data;


### PR DESCRIPTION
See https://github.com/canjs/can-util/issues/225. We are now using `Array.isArray` directly.