### PR TITLE
chore(package): update can-util to version 3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "can-stache": "^3.1.0",
     "can-stache-bindings": "^3.2.0",
     "can-types": "^1.1.0",
-    "can-util": "^3.9.0",
+    "can-util": "^3.9.5",
     "can-validate-interface": "0.1.0",
     "can-view-callbacks": "^3.1.0",
     "can-view-nodelist": "^3.1.0",


### PR DESCRIPTION
Fixes #319 