### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "can-compute": "^3.3.1",
     "can-construct": "^3.2.0",
     "can-define": "^1.2.0",
-    "can-event": "^3.5.0",
+    "can-event": "^3.6.0",
     "can-list": "^3.1.0",
     "can-make-rest": "0.1.1",
     "can-map": "^3.3.1",


### PR DESCRIPTION
Closes #274 