### PR TITLE
Replaced console with canLog from can-util

### DIFF
--- a/service-worker/service-worker.js
+++ b/service-worker/service-worker.js
@@ -1,6 +1,7 @@
 
 var connect = require("can-connect");
 var makeDeferred = require("can-connect/helpers/deferred");
+var canLog = require("can-util/js/log/log");
 
 /**
  * @module can-connect/service-worker
@@ -29,7 +30,7 @@ module.exports = connect.behavior("service-worker",function(baseConnection){
 		return def.promise;
 	};
 	worker.onmessage = function(ev){
-		console.log("MAIN - got message", ev.data.type);
+		canLog.log("MAIN - got message", ev.data.type);
 		if(ev.data.type === "ready"){
 			isReady.resolve();
 		} else if(ev.data.type === "response") {


### PR DESCRIPTION
In IE9 window.console is not available unless the dev tools are open and will silently break execution anytime it is referenced.

Replaces console with our canLog function from can-util

For canjs/canjs#3482