### PR TITLE
Fix destroy when server returns non-identifying object or 204 No Content

### DIFF
--- a/constructor/store/store.js
+++ b/constructor/store/store.js
@@ -677,11 +677,15 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 		 */
 		destroy: function(instance) {
 			var self = this;
+			// Add to instance store, for the duration of the
+			// destroy callback
+			this.addInstanceReference(instance);
 			requests.increment(this);
 			var promise = baseConnection.destroy.call(this, instance);
 
 			promise.then(function(instance){
 				self._finishedRequest();
+				self.deleteInstanceReference(instance);
 			}, function(){
 				self._finishedRequest();
 			});


### PR DESCRIPTION
Fixes #365

This fix temporarily adds instances to the instanceStore while they are being delete, so that list with bound `length` will still have the proper instances removed when destroying an instance while using the `real-time` behaviour.

This particular fix will solve the problem for when the server/fixtures respond with an empty object or some JSON that does not identify (with an `id` for example) the instance BUT this will also fix the case for `204 No Content` (a common delete response on some restful services), as soon as [this issue](https://github.com/canjs/can-ajax/issues/19) is fixed in **`can-ajax`**