### PR TITLE
Fix bug where properties in a getList response weren’t being returned

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -271,7 +271,7 @@ var canMapBehavior = connect.behavior("can/map",function(baseConnection){
 			var list = new _List(listData.data);
 			each(listData, function (val, prop) {
 				if (prop !== 'data') {
-					canReflect.setKeyValue(prop, val);
+					canReflect.setKeyValue(list, prop, val);
 				}
 			});
 

--- a/can/map/map_test.js
+++ b/can/map/map_test.js
@@ -486,3 +486,22 @@ QUnit.test("reads id from set algebra (#82)", function(){
 
 	QUnit.equal(todoConnection.id(new Todo({_id: 5})), 5, "got the right id");
 });
+
+QUnit.test("additional properties are included in getList responses", function(){
+	fixture({
+		"GET /services/todos": function(){
+			return {
+				count: 1,
+				data: [{id: 1}]
+			};
+		}
+	});
+
+	var Todo = this.Todo;
+
+	stop();
+	Todo.getList({}).then(function(todos){
+		equal(todos.count, 1);
+		start();
+	});
+});


### PR DESCRIPTION
This fixes an issue where a `getList()` call would be made and the response would contain additional properties (e.g. `count`), but the properties would not be set on the object returned by `getList()`.

Closes https://github.com/canjs/canjs/issues/2980