### PR TITLE
constructor/store: add references to instances in list when adding reference to list

### DIFF
--- a/can/map/map_test.js
+++ b/can/map/map_test.js
@@ -34,6 +34,8 @@ var logErrorAndStart = function(e){
 	start();
 };
 
+constructorStore.requestCleanupDelay = 1;
+
 QUnit.module("can-connect/can/map/map",{
 	setup: function(){
 

--- a/can/model/model.js
+++ b/can/model/model.js
@@ -228,6 +228,7 @@ var CanModel = CanMap.extend({
 				)
 			)
 		);
+		this.connection.init();
 
 		this.store = this.connection.instanceStore;
 		// map static stuff to crud .. but we don't want this inherited by the next thing'

--- a/can/model/model_test.js
+++ b/can/model/model_test.js
@@ -9,7 +9,7 @@ var canEvent = require("can-event");
 var CanMap = require("can-map");
 var CanList = require("can-list");
 var Observation = require("can-observation");
-
+var constructorStore = require("can-connect/constructor/store/store");
 var assign = require("can-util/js/assign/assign");
 
 var logErrorAndStart = function(e){
@@ -17,6 +17,7 @@ var logErrorAndStart = function(e){
 	start();
 };
 
+constructorStore.requestCleanupDelay = 1;
 
 (function () {
 	QUnit.module('can-connect/can/model', {

--- a/constructor/store/store.js
+++ b/constructor/store/store.js
@@ -107,7 +107,10 @@ var requests = {
 		if(pendingRequests === 0) {
 			noRequestsTimer = setTimeout(function(){
 				requests.dispatch("end");
-			},10);
+			},module.exports.requestCleanupDelay);
+		}
+		if(pendingRequests < 0) {
+			pendingRequests = 0;
 		}
 	},
 	count: function(){
@@ -161,21 +164,39 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 		 * ```
 		 */
 		listStore: new WeakReferenceMap(),
-		_requestInstances: {},
-		_requestLists: {},
-		_finishedRequest: function(){
-			var id;
-			requests.decrement(this);
-			if(requests.count() === 0) {
+		 // Set up the plain objects for tracking requested lists and instances for this connection,
+		 // and add a handler to the requests counter to flush list and instance references when all
+		 // requests have completed
+		 //
+		 // This function is called automatically when connect() is called on this behavior,
+		 // and should not need to be called manually.
+		init: function() {
+			if(baseConnection.init) {
+				baseConnection.init.apply(this, arguments);
+			}
+
+			if(!this.hasOwnProperty("_requestInstances")) {
+				this._requestInstances = {};
+			}
+			if(!this.hasOwnProperty("_requestLists")) {
+				this._requestLists = {};
+			}
+
+			requests.on("end", function(){
+				var id;
 				for(id in this._requestInstances) {
 					this.instanceStore.deleteReference(id);
 				}
 				this._requestInstances = {};
 				for(id in this._requestLists) {
 					this.listStore.deleteReference(id);
+					this._requestLists[id].forEach(this.deleteInstanceReference.bind(this));
 				}
 				this._requestLists = {};
-			}
+			}.bind(this));
+		},
+		_finishedRequest: function(){
+			requests.decrement(this);
 		},
 
 		/**
@@ -416,6 +437,9 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 			var id = sortedSetJSON( set || this.listSet(list) );
 			if(id) {
 				this.listStore.addReference( id, list );
+				list.forEach(function(instance) {
+					this.addInstanceReference(instance);
+				}.bind(this));
 			}
 		},
 		/**
@@ -451,6 +475,7 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 			var id = sortedSetJSON( set || this.listSet(list) );
 			if(id) {
 				this.listStore.deleteReference( id, list );
+				list.forEach(this.deleteInstanceReference.bind(this));
 			}
 		},
 		/**
@@ -691,6 +716,38 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 			});
 			return promise;
 
+		},
+		/**
+		 * @function can-connect/constructor/store/store.updatedList updatedList
+		 * @parent can-connect/constructor/store/store.callbacks
+		 *
+		 * Extends the underlying [can-connect/connection.updatedList] so any instances that have been added or removed
+		 * from the list have their reference counts updated accordingly.
+		 *
+		 * @signature `connection.updatedList( list, listData, set )`
+		 * Increments an internal request counter so instances on this list during this request will be stored, and decrements
+		 * the same counter for all items previously on the list (found in `listData.data`).
+		 *
+		 * @param {can-connect.List} list a typed list of instances being updated
+		 * @param {Object} listData an object representing the previous state of the list
+		 * @param {Object} set the retrieval set used to get the list
+		 */
+		updatedList: function(list, listData, set) {
+			var oldList = list.slice(0);
+			if(!listData.data && typeof listData.length === "number") {
+				listData = { data: listData };
+			}
+			if(baseConnection.updatedList) {
+				baseConnection.updatedList.call(this, list, listData, set);
+				list.forEach(function(instance) {
+					this.addInstanceReference(instance);
+				}.bind(this));
+			} else if(listData.data) {
+				listData.data.forEach(function(instance) {
+					this.addInstanceReference(instance);
+				}.bind(this));
+			}
+			oldList.forEach(this.deleteInstanceReference.bind(this));
 		}
 	};
 
@@ -698,6 +755,14 @@ var constructorStore = connect.behavior("constructor/store",function(baseConnect
 
 });
 constructorStore.requests = requests;
+// The number of ms to wait after all known requests have finished,
+//  before starting request cleanup.
+// If a new request comes in before timeout, wait until that request
+//  has finished (+ delay) before starting cleanup.
+// This is configurable, for use cases where more waiting is desired,
+//  or for the can-connect tests which expect everything to clean up
+//  in 1ms.
+constructorStore.requestCleanupDelay = 10;
 
 module.exports = constructorStore;
 

--- a/fall-through-cache/fall-through-cache_test.js
+++ b/fall-through-cache/fall-through-cache_test.js
@@ -12,6 +12,8 @@ var getId = function(d){
 	return d.id;
 };
 
+constructorStore.requestCleanupDelay = 1;
+
 QUnit.module("can-connect/fall-through-cache");
 
 QUnit.test("basics", function(){

--- a/helpers/map-deep-merge-test.js
+++ b/helpers/map-deep-merge-test.js
@@ -10,6 +10,7 @@ var canMap = require('can-connect/can/map/map');
 var dataUrl = require('can-connect/data/url/url');
 var constructor = require('can-connect/constructor/constructor');
 var constructorStore = require('can-connect/constructor/store/store');
+constructorStore.requestCleanupDelay = 1;
 
 var smartMerge = require('./map-deep-merge');
 var applyPatch = require('./map-deep-merge').applyPatch;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "can-connect.js",
   "dependencies": {
     "can-ajax": "^1.1.4",
-    "can-attribute-encoder": "^1.0.0",
     "can-compute": "^3.3.1",
     "can-construct": "^3.2.0",
     "can-define": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "can-connect.js",
   "dependencies": {
     "can-ajax": "^1.1.4",
+    "can-attribute-encoder": "^1.0.0",
     "can-compute": "^3.3.1",
     "can-construct": "^3.2.0",
     "can-define": "^1.2.0",

--- a/real-time/real-time_test.js
+++ b/real-time/real-time_test.js
@@ -26,6 +26,7 @@ var logErrorAndStart = function(e){
 	start();
 };
 
+constructorStore.requestCleanupDelay = 1;
 
 QUnit.test("basics", function(){
 	// get two lists


### PR DESCRIPTION
This prevents duplicate constructor instances when instances aren't directly bound, but are members of a list which is bound.

We saw this happening in Equibit and it made post-processing after loading items not work well (since an instance may have two or more copies, and the wrong one got the post-processing).

This PR is against the legacy 1.x versions of can-connect (CanJS 3.0 legacy), but after review, may also benefit the latest master branch as well.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
