### PR TITLE
Prevent trying to remove and insert a value in the same place

### DIFF
--- a/real-time/real-time.js
+++ b/real-time/real-time.js
@@ -163,6 +163,10 @@ function updateList(list, getRecord, currentIndex, newIndex) {
 
 
 function updateListWithItem(list, recordData, currentIndex, newIndex, connection, set){
+	// we are inserting right where we already are.
+	if(newIndex === currentIndex+1 || newIndex === currentIndex) {
+		return;
+	}
 	if(list[spliceSymbol] !== undefined) {
 		updateList(list, function(){
 			return connection.hydrateInstance(recordData);


### PR DESCRIPTION
fixes #436

`updateListWithItem` is used to update the position of records within a list.  This was updating positions even if the list was going to end up removing and then inserting the record back in the place it was positioned.

I check to make sure that if the indexes indicate this is going to happen.  