### PR TITLE
include the "can/map" behavior as part of the module export

### DIFF
--- a/all.js
+++ b/all.js
@@ -16,6 +16,10 @@ connect.dataUrl = require("./data/url/url");
 connect.fallThroughCache = require("./fall-through-cache/fall-through-cache");
 connect.realTime = require("./real-time/real-time");
 
+connect.canMap = require("./can/map/map");
+connect.canRef = require("./can/ref/ref");
+connect.canMerge = require("./can/merge/merge");
+
 connect.superMap = require("./can/super-map/super-map");
 connect.baseMap = require('./can/base-map/base-map');
 

--- a/all.js
+++ b/all.js
@@ -17,8 +17,6 @@ connect.fallThroughCache = require("./fall-through-cache/fall-through-cache");
 connect.realTime = require("./real-time/real-time");
 
 connect.canMap = require("./can/map/map");
-connect.canRef = require("./can/ref/ref");
-connect.canMerge = require("./can/merge/merge");
 
 connect.superMap = require("./can/super-map/super-map");
 connect.baseMap = require('./can/base-map/base-map');


### PR DESCRIPTION
Include these behaviors so they can be conveniently used for codepen demos of can-connect. Eventually all behaviors will be broken out into their own packages.