### PR TITLE
Use can.new symbol to create new List types

### DIFF
--- a/can/map/map.js
+++ b/can/map/map.js
@@ -336,7 +336,7 @@ var canMapBehavior = behavior("can/map",function(baseConnection){
 		 */
 		list: function(listData, set){
 			var _List = this.List || (this.Map && this.Map.List);
-			var list = new _List(listData.data);
+			var list = canReflect.new(_List, listData.data);
 			canReflect.eachKey(listData, function (val, prop) {
 				if (prop !== 'data') {
 					canReflect.setKeyValue(list, prop, val);

--- a/can/map/map_test.js
+++ b/can/map/map_test.js
@@ -3,6 +3,7 @@ var $ = require("jquery");
 var Map = require("can-map");
 var List = require("can-list");
 var Observation = require("can-observation");
+var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 
 // load connections
@@ -537,4 +538,32 @@ QUnit.test("should batch model events", function(assert) {
 	queues.batch.stop();
 
 	assert.equal(eventOrder.join(""), "1234", "events are batched");
+});
+
+QUnit.test("list uses can.new", function(assert) {
+	var Todo = function(props) {};
+	var TodoList = function() {
+		var array = Array.apply(this, arguments);
+		return array;
+	};
+	TodoList[canSymbol.for("can.new")] = function(items) {
+		var list = new TodoList();
+		return TodoList.apply(list, items);
+	};
+
+	var todoConnection = connect([
+		constructor,
+		canMap],
+		{
+			url: "/services/todos",
+			Map: Todo,
+			List: TodoList
+		});
+
+	var list = todoConnection.list({
+		data: [{id:1, label: "walk the dog"},
+			{id:2, label: "make dinner"}]
+	});
+
+	assert.equal(list.length, 2, "Has all of the items");
 });


### PR DESCRIPTION
This changes it so that lists are created with `can.new`. This allows
for list types whose constructor do not expect a single argument as an
array. They can implement a `can.new` that takes the single array value
and does whatever they need to create their new list.