### PR TITLE
weak-reference-set does mutiple entries support

### DIFF
--- a/helpers/helpers_test.js
+++ b/helpers/helpers_test.js
@@ -1,4 +1,5 @@
 require("./map-deep-merge-test");
+require("./weak-reference-set-test");
 
 var idMerge = require("./id-merge");
 

--- a/helpers/weak-reference-set-test.js
+++ b/helpers/weak-reference-set-test.js
@@ -1,0 +1,39 @@
+var QUnit = require('steal-qunit');
+var WeakReferenceSet = require('./weak-reference-set');
+
+QUnit.module("weak-reference-set");
+
+QUnit.test("Multiple entries support #468", function(assert) {
+	var set = new WeakReferenceSet();
+
+	var item1 = {};
+	var item2 = {};
+	var item3 = {};
+
+	var items = [item1, item2, item3];
+
+	for (var index = 0; index < items.length; index++) {
+		set.addReference(items[index]);
+	}
+	
+	assert.equal(set.get(item1), item1, "Got the first item");
+	assert.equal(set.get(item2), item2, "Got the second item");
+	assert.equal(set.get(item3), item3, "Got the third item");
+});
+
+QUnit.test("Multiple entries support with multiple reference #468", function(assert) {
+	var set = new WeakReferenceSet();
+
+	var obj = {};
+	var obj2 = {};
+
+	for (var index = 0; index < 3; index++) {
+		set.addReference(obj);
+	}
+
+	set.addReference(obj2);
+
+	assert.equal(set.referenceCount(obj), 3, "Got the correct reference count");
+	assert.equal(set.referenceCount(obj2), 1, "Got correct reference count for multiple entries");
+});
+

--- a/helpers/weak-reference-set.js
+++ b/helpers/weak-reference-set.js
@@ -63,6 +63,7 @@ assign(WeakReferenceSet.prototype,{
 				index = i;
 				return false;
 			}
+			return true;
 		});
 		return index !== undefined ? index : -1;
 	},


### PR DESCRIPTION
This adds the ability to support multiple entries for [weak-reference-set](https://github.com/canjs/can-connect/blob/3d1c0347a8e64a9c687e511ff9a303fdbf90fa38/helpers/weak-reference-set.js):

```js
var set = new WeakReferenceSet();

var item1 = {};
var item2 = {};
var item3 = {};

set.addReference(item1);
set.addReference(item2);
set.addReference(item3);

set.get(item1) // => item1
set.get(item2) // => item2
set.get(item3) // => item3
```

Fixes #468 


      

