### PR TITLE
Remove npm version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,6 @@
   "keywords": [
     "CanJS"
   ],
-  "engines": {
-    "npm": "^3.0.0"
-  },
   "author": "Bitovi",
   "license": "MIT"
 }


### PR DESCRIPTION
Remove the hardcoded `npm` version from `package.json`.

Fixes https://github.com/canjs/canjs/issues/5161