### PR TITLE
Re-enable a skipped test

### DIFF
--- a/real-time/real-time_test.js
+++ b/real-time/real-time_test.js
@@ -29,7 +29,7 @@ var logErrorAndStart = function(e){
 
 constructorStore.requestCleanupDelay = 1;
 
-QUnit.skip("basics", function(assert) {
+QUnit.test("basics", function(assert) {
 	// get two lists
 	// user creates / updates / destroys things
 	// real-time creates / updates / destroys things


### PR DESCRIPTION
I’m not sure why it was skipped in https://github.com/canjs/can-connect/pull/469 but it passes.