### PR TITLE
Bump the semver range for can-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "can-set-legacy": "<2.0.0",
     "can-simple-observable": "^2.0.0",
     "can-test-helpers": "^1.1.2",
-    "can-type": "^0.1.13",
+    "can-type": "^0.2.0",
     "http-server": "^0.11.0",
     "jquery": "2.x - 3.x",
     "jshint": "^2.9.4",


### PR DESCRIPTION
The previous range wasn’t compatible with what was in the main `can` build.