### PR TITLE
Fix bundlers build

### DIFF
--- a/cache-requests/cache-requests.js
+++ b/cache-requests/cache-requests.js
@@ -282,6 +282,6 @@ module.exports = cacheRequestsBehaviour;
 //!steal-remove-start
 if(process.env.NODE_ENV !== 'production') {
 	var validate = require("../helpers/validate");
+	module.exports = validate(cacheRequestsBehaviour, ['getListData', 'cacheConnection']);
 }
-module.exports = validate(cacheRequestsBehaviour, ['getListData', 'cacheConnection']);
 //!steal-remove-end


### PR DESCRIPTION
A `module.exports` was inside a `!steal-remove` block but outside a `process.env.NODE_ENV` check, causing production webpack builds to be broken.
Same as #506 but for `v3.2.x`.

Closes #509 