### PR TITLE
Batched createdInstance and updateInstance in save method (#5518)

### DIFF
--- a/constructor/constructor_test.js
+++ b/constructor/constructor_test.js
@@ -129,13 +129,12 @@ QUnit.test("atomic saving for createdInstance and updateInstance (#5518)", funct
 	var callArgs = [];
 
 	var p = new Person({name: "ed"});
-
 	// Observer made to p
-	var person = observe(p);
+	var personObserver = observe(p);
 	
-	// Observation made on person
+	// Observation made on personObserver
 	var nameAndDate = new Observation(function() {
-		return person.name + " " + person.createdAt;
+		return personObserver.name + " " + personObserver.createdAt;
 	});
 	
 	nameAndDate.on(function(value) {
@@ -144,14 +143,14 @@ QUnit.test("atomic saving for createdInstance and updateInstance (#5518)", funct
 	
 	// The properties that are set are batched together
 	queues.batch.start();
-	person.name = "edward";
-	person.createdAt = "10-07-13";
+	personObserver.name="edward";
+	personObserver.createdAt = "10-07-13";
 	queues.batch.stop();
-	
+
 	// Saving p should be done once
-	peopleConnection.save(p).then(function(updatedP) {
+	peopleConnection.save(p).then(function() {
 		assert.deepEqual(callArgs, ["edward 10-07-13"])
-		assert.equal(p, updatedP, "same instances");
+		assert.deepEqual(p, personObserver, "same instances");
 	}, testHelpers.logErrorAndStart(assert, done));
 
 	Promise.all(promises).then(done, done);


### PR DESCRIPTION
A batch is now started/stopped when properties are created or set on instances.  Test written for this behavior.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
