### PR TITLE
check if props exist before running connection.id

### DIFF
--- a/can/constructor-hydrate/constructor-hydrate-test.js
+++ b/can/constructor-hydrate/constructor-hydrate-test.js
@@ -54,3 +54,23 @@ QUnit.test("Two objects with no id", function(assert) {
 	new Hub({name: 'One'});
 	assert.ok(true, 'Should allow to create two instances without an id (no Max Call Stack error)');
 });
+
+QUnit.test("No Props passed to new DefineMap, doesn't blow up", function(assert) {
+	var Hub = DefineMap.extend({});
+	Hub.List = DefineList.extend({
+		'#': { Type: Hub }
+	});
+	var HubConnection = connect([
+		constructorBehavior,
+		constructorStore,
+		mapBehavior,
+		hydrateBehavior,
+	], { Map: Hub, List: Hub.List });
+
+	var hub1 = new Hub();
+	hub1.name = 'One';
+	HubConnection.addInstanceReference(hub1);
+	assert.ok(!HubConnection.instanceStore.has(undefined), 'The instanceStore should not have an "undefined" key item');
+	new Hub({name: 'One'});
+	assert.ok(true, 'Should allow to create two instances without an id (no Max Call Stack error)');
+});

--- a/can/constructor-hydrate/constructor-hydrate.js
+++ b/can/constructor-hydrate/constructor-hydrate.js
@@ -105,9 +105,9 @@ var constructorHydrateBehavior = connect.behavior("can-connect/can/construct-hyd
 			this.Map.prototype.setup = function(props){
 				if (
 					canReflect.isMapLike(props) && 
-					connection.instanceStore.has( connection.id(props) )
+					connection.instanceStore.has(connection.id(props))
 				) {
-					return new Construct.ReturnValue( connection.hydrateInstance(props) );
+					return new Construct.ReturnValue(connection.hydrateInstance(props));
 				}
 				return oldSetup.apply(this, arguments);
 			};

--- a/can/constructor-hydrate/constructor-hydrate.js
+++ b/can/constructor-hydrate/constructor-hydrate.js
@@ -95,6 +95,7 @@
 
 var connect = require("../../can-connect");
 var Construct = require("can-construct");
+var canReflect = require("can-reflect");
 
 var constructorHydrateBehavior = connect.behavior("can-connect/can/construct-hydrate", function(baseConnect){
 	return {
@@ -102,7 +103,10 @@ var constructorHydrateBehavior = connect.behavior("can-connect/can/construct-hyd
 			var oldSetup = this.Map.prototype.setup;
 			var connection = this;
 			this.Map.prototype.setup = function(props){
-				if (props && connection.instanceStore.has( connection.id(props) )) {
+				if (
+					canReflect.isMapLike(props) && 
+					connection.instanceStore.has( connection.id(props) )
+				) {
 					return new Construct.ReturnValue( connection.hydrateInstance(props) );
 				}
 				return oldSetup.apply(this, arguments);

--- a/can/constructor-hydrate/constructor-hydrate.js
+++ b/can/constructor-hydrate/constructor-hydrate.js
@@ -102,7 +102,7 @@ var constructorHydrateBehavior = connect.behavior("can-connect/can/construct-hyd
 			var oldSetup = this.Map.prototype.setup;
 			var connection = this;
 			this.Map.prototype.setup = function(props){
-				if (connection.instanceStore.has( connection.id(props) )) {
+				if (props && connection.instanceStore.has( connection.id(props) )) {
 					return new Construct.ReturnValue( connection.hydrateInstance(props) );
 				}
 				return oldSetup.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "steal-qunit": "^2.0.0",
     "steal-tools": "^1.0.0",
     "test-saucelabs": "^0.0.6",
-    "testee": "^0.9.0"
+    "testee": "^0.10.2"
   },
   "steal": {
     "plugins": [

--- a/test/test-saucelabs.js
+++ b/test/test-saucelabs.js
@@ -2,9 +2,9 @@
 
 var SauceLabs = require("test-saucelabs");
 
-// var maxDuration = 10800; // seconds, default 1800, max 10800
-// var commandTimeout = 600; // seconds, default 300, max 600
-// var idleTimeout = 1000; // seconds, default 90, max 1000
+var maxDuration = 10800; // seconds, default 1800, max 10800
+var commandTimeout = 600; // seconds, default 300, max 600
+var idleTimeout = 1000; // seconds, default 90, max 1000
 
 // https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
 var platforms = [{
@@ -31,21 +31,21 @@ var platforms = [{
 
 SauceLabs({
 	urls: [{
-// 		name: "can-connect",
-// 		url : 'http://localhost:3000/test/test-ie.html?hidepassed',
-// 		platforms: [{
-// 			browserName: 'internet explorer',
-// 			platform: 'Windows 10',
-// 			version: '11.0',
-// 			maxDuration: maxDuration,
-// 			commandTimeout: commandTimeout,
-// 			idleTimeout: idleTimeout
-// 		}]
-// 	}, {
+		name: "can-connect",
+		url : 'http://localhost:3000/test/test-ie.html?hidepassed',
+		platforms: [{
+			browserName: 'internet explorer',
+			platform: 'Windows 10',
+			version: '11.0',
+			maxDuration: maxDuration,
+			commandTimeout: commandTimeout,
+			idleTimeout: idleTimeout
+		}]
+	}, {
 		name: "can-connect",
 		url: "http://localhost:3000/test/test.html?hidepassed",
 		platforms: platforms
 	}],
-	runInSeries: true,
+	runInParallel: false,
 	zeroAssertionsPass: false
 });

--- a/test/test-saucelabs.js
+++ b/test/test-saucelabs.js
@@ -2,9 +2,9 @@
 
 var SauceLabs = require("test-saucelabs");
 
-var maxDuration = 10800; // seconds, default 1800, max 10800
-var commandTimeout = 600; // seconds, default 300, max 600
-var idleTimeout = 1000; // seconds, default 90, max 1000
+// var maxDuration = 10800; // seconds, default 1800, max 10800
+// var commandTimeout = 600; // seconds, default 300, max 600
+// var idleTimeout = 1000; // seconds, default 90, max 1000
 
 // https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
 var platforms = [{

--- a/test/test-saucelabs.js
+++ b/test/test-saucelabs.js
@@ -31,17 +31,17 @@ var platforms = [{
 
 SauceLabs({
 	urls: [{
-		name: "can-connect",
-		url : 'http://localhost:3000/test/test-ie.html?hidepassed',
-		platforms: [{
-			browserName: 'internet explorer',
-			platform: 'Windows 10',
-			version: '11.0',
-			maxDuration: maxDuration,
-			commandTimeout: commandTimeout,
-			idleTimeout: idleTimeout
-		}]
-	}, {
+// 		name: "can-connect",
+// 		url : 'http://localhost:3000/test/test-ie.html?hidepassed',
+// 		platforms: [{
+// 			browserName: 'internet explorer',
+// 			platform: 'Windows 10',
+// 			version: '11.0',
+// 			maxDuration: maxDuration,
+// 			commandTimeout: commandTimeout,
+// 			idleTimeout: idleTimeout
+// 		}]
+// 	}, {
 		name: "can-connect",
 		url: "http://localhost:3000/test/test.html?hidepassed",
 		platforms: platforms


### PR DESCRIPTION
Test demonstrates the issue.
connection.id requires props to be an object, otherwise it will throw. This is correct behavior, however it is not correct for hydrate to assume new DefineMap will have a property passed to it. DefineMap does not require a property to be passed, so hydrate should make a check before making any calls to functions that require props.
